### PR TITLE
fix: path traversal guard + SPA method check

### DIFF
--- a/server/dev.ts
+++ b/server/dev.ts
@@ -55,6 +55,10 @@ const stubAssets = {
     ? async (req: Request) => {
         const url = new URL(req.url);
         const filePath = resolve(publicDir, url.pathname.replace(/^\//, ''));
+        // Prevent path traversal — resolved path must stay inside publicDir
+        if (!filePath.startsWith(publicDir + '/') && filePath !== publicDir) {
+          return new Response('Forbidden', { status: 403 });
+        }
         try {
           if (statSync(filePath).isFile()) {
             const body = readFileSync(filePath);
@@ -62,8 +66,10 @@ const stubAssets = {
             return new Response(body, { headers: { 'content-type': mime } });
           }
         } catch {}
-        // SPA fallback: return index.html for non-file routes
-        if (indexHtml) return new Response(indexHtml, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+        // SPA fallback: return index.html only for GET requests
+        if (req.method === 'GET' && indexHtml) {
+          return new Response(indexHtml, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+        }
         return new Response('Not found', { status: 404 });
       }
     : async () => new Response('Not found', { status: 404 }),


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #83 (CodeRabbit + Copilot)
- Adds path traversal guard: resolved paths must stay within `publicDir`
- SPA fallback only returns `index.html` for GET requests; POST/PUT/DELETE to unknown routes return 404

## Test plan
- [x] `GET /` → 200 HTML
- [x] `GET /assets/*.css` → 200 correct MIME
- [x] `GET /dashboard` → 200 SPA fallback
- [x] `POST /nonexistent` → 404 (not HTML)
- [x] Path traversal (`/../../server/dev.ts`) → blocked by guard
- [x] `GET /health` → 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by validating asset request paths to prevent directory traversal and unauthorized access
  * Refined single-page application fallback behavior to return proper 404 responses for non-GET requests instead of serving the index file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->