### PR TITLE
feat: COA classification API + auto-suggest on import

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -37,6 +37,7 @@ import { workflowRoutes } from './routes/workflows';
 import { leaseRoutes } from './routes/leases';
 import { chittyIdAuthRoutes } from './routes/chittyid-auth';
 import { allocationRoutes } from './routes/allocations';
+import { classificationRoutes } from './routes/classification';
 import { createDb } from './db/connection';
 import { SystemStorage } from './storage/system';
 
@@ -98,7 +99,7 @@ export function createApp() {
     '/api/accounts', '/api/transactions', '/api/properties',
     '/api/integrations', '/api/tasks', '/api/ai-messages', '/api/ai', '/api/summary',
     '/api/mercury', '/api/github', '/api/charges', '/api/forensics', '/api/portfolio', '/api/import', '/api/reports',
-    '/api/google', '/api/comms', '/api/workflows', '/api/leases', '/mcp',
+    '/api/google', '/api/comms', '/api/workflows', '/api/leases', '/api/coa', '/api/classification', '/mcp',
   ];
   app.use('/api/tenants', ...authAndContext);
   app.use('/api/tenants/*', ...authAndContext);
@@ -128,6 +129,7 @@ export function createApp() {
   app.route('/', reportRoutes);
   app.route('/', taxRoutes);
   app.route('/', allocationRoutes);
+  app.route('/', classificationRoutes);
   app.route('/', googleRoutes);
   app.route('/', commsRoutes);
   app.route('/', workflowRoutes);

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -1,9 +1,55 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { HonoEnv } from '../env';
 import { ledgerLog } from '../lib/ledger-client';
 import { findAccountCode } from '../../database/chart-of-accounts';
 
 export const classificationRoutes = new Hono<HonoEnv>();
+
+// Roles permitted to modify the Chart of Accounts (L4 Govern).
+// Only tenant owners and admins can add/edit/retire COA accounts.
+const L4_ROLES = new Set(['owner', 'admin']);
+
+// Query param schemas
+const limitQuerySchema = z.coerce.number().int().min(1).max(500).default(50);
+const batchLimitQuerySchema = z.coerce.number().int().min(1).max(500).default(100);
+
+// Body schemas
+const classifyBodySchema = z.object({
+  transactionId: z.string().uuid(),
+  coaCode: z.string().min(1),
+  confidence: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+const reconcileBodySchema = z.object({
+  transactionId: z.string().uuid(),
+});
+
+const coaCreateSchema = z.object({
+  code: z.string().min(1).max(10),
+  name: z.string().min(1),
+  type: z.enum(['asset', 'liability', 'equity', 'income', 'expense']),
+  subtype: z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
+  scheduleELine: z.string().optional().nullable(),
+  taxDeductible: z.boolean().optional(),
+  parentCode: z.string().optional().nullable(),
+});
+
+const coaUpdateSchema = coaCreateSchema.partial();
+
+/** Require L4 (tenant owner/admin) for COA mutations. Returns null if allowed, or a 403 Response. */
+async function requireL4(c: any): Promise<Response | null> {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const role = await storage.getUserRoleForTenant(userId, tenantId);
+  if (!role || !L4_ROLES.has(role)) {
+    return c.json({ error: 'forbidden', message: 'L4 (owner or admin) role required to modify Chart of Accounts' }, 403);
+  }
+  return null;
+}
 
 // GET /api/coa — list Chart of Accounts for current tenant (includes global defaults)
 classificationRoutes.get('/api/coa', async (c) => {
@@ -22,31 +68,34 @@ classificationRoutes.get('/api/coa/global', async (c) => {
 
 // POST /api/coa — create a tenant-specific COA account (L4 only)
 classificationRoutes.post('/api/coa', async (c) => {
+  const forbidden = await requireL4(c);
+  if (forbidden) return forbidden;
+
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
-  const body = await c.req.json();
-
-  const { code, name, type, subtype, description, scheduleELine, taxDeductible, parentCode } = body;
-  if (!code || !name || !type) {
-    return c.json({ error: 'code, name, and type are required' }, 400);
-  }
-
-  const existing = await storage.getChartOfAccountByCode(code, tenantId);
-  if (existing && existing.tenantId === tenantId) {
-    return c.json({ error: `Account code ${code} already exists for this tenant` }, 409);
-  }
-
   const userId = c.get('userId');
+
+  const parsed = coaCreateSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
+  }
+  const body = parsed.data;
+
+  const existing = await storage.getChartOfAccountByCode(body.code, tenantId);
+  if (existing && existing.tenantId === tenantId) {
+    return c.json({ error: `Account code ${body.code} already exists for this tenant` }, 409);
+  }
+
   const account = await storage.createChartOfAccount({
     tenantId,
-    code,
-    name,
-    type,
-    subtype: subtype ?? null,
-    description: description ?? null,
-    scheduleELine: scheduleELine ?? null,
-    taxDeductible: taxDeductible ?? false,
-    parentCode: parentCode ?? null,
+    code: body.code,
+    name: body.name,
+    type: body.type,
+    subtype: body.subtype ?? null,
+    description: body.description ?? null,
+    scheduleELine: body.scheduleELine ?? null,
+    taxDeductible: body.taxDeductible ?? false,
+    parentCode: body.parentCode ?? null,
     isActive: true,
     modifiedBy: userId,
   });
@@ -54,30 +103,38 @@ classificationRoutes.post('/api/coa', async (c) => {
   ledgerLog(c, {
     entityType: 'audit',
     action: 'coa.create',
-    metadata: { tenantId, code, name, type, actorId: userId },
+    metadata: { tenantId, code: body.code, name: body.name, type: body.type, actorId: userId },
   }, c.env);
 
   return c.json(account, 201);
 });
 
-// PATCH /api/coa/:id — update a COA account (L4 only)
+// PATCH /api/coa/:id — update a tenant-specific COA account (L4 only, tenant-scoped)
 classificationRoutes.patch('/api/coa/:id', async (c) => {
-  const storage = c.get('storage');
-  const id = c.req.param('id');
-  const body = await c.req.json();
-  const userId = c.get('userId');
+  const forbidden = await requireL4(c);
+  if (forbidden) return forbidden;
 
-  const account = await storage.updateChartOfAccount(id, {
-    ...body,
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const id = c.req.param('id');
+
+  const parsed = coaUpdateSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
+  }
+
+  const account = await storage.updateChartOfAccount(id, tenantId, {
+    ...parsed.data,
     modifiedBy: userId,
   });
 
-  if (!account) return c.json({ error: 'Account not found' }, 404);
+  if (!account) return c.json({ error: 'Account not found or not owned by this tenant' }, 404);
 
   ledgerLog(c, {
     entityType: 'audit',
     action: 'coa.update',
-    metadata: { id, changes: Object.keys(body), actorId: userId },
+    metadata: { id, changes: Object.keys(parsed.data), actorId: userId },
   }, c.env);
 
   return c.json(account);
@@ -101,8 +158,11 @@ classificationRoutes.get('/api/classification/stats', async (c) => {
 classificationRoutes.get('/api/classification/unclassified', async (c) => {
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
-  const limit = parseInt(c.req.query('limit') || '50', 10);
-  const txns = await storage.getUnclassifiedTransactions(tenantId, limit);
+  const limitParsed = limitQuerySchema.safeParse(c.req.query('limit'));
+  if (!limitParsed.success) {
+    return c.json({ error: 'invalid_limit', message: 'limit must be an integer between 1 and 500' }, 400);
+  }
+  const txns = await storage.getUnclassifiedTransactions(tenantId, limitParsed.data);
   return c.json(txns);
 });
 
@@ -111,23 +171,28 @@ classificationRoutes.post('/api/classification/suggest', async (c) => {
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
   const userId = c.get('userId');
-  const { transactionId, coaCode, confidence, reason } = await c.req.json();
 
-  if (!transactionId || !coaCode) {
-    return c.json({ error: 'transactionId and coaCode are required' }, 400);
+  const parsed = classifyBodySchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
   }
+  const { transactionId, coaCode, confidence, reason } = parsed.data;
 
-  const result = await storage.classifyTransaction(transactionId, tenantId, coaCode, {
-    actorId: userId,
-    actorType: 'user',
-    trustLevel: 'L1',
-    confidence,
-    reason,
-    isSuggestion: true,
-  });
+  try {
+    const result = await storage.classifyTransaction(transactionId, tenantId, coaCode, {
+      actorId: userId,
+      actorType: 'user',
+      trustLevel: 'L1',
+      confidence,
+      reason,
+      isSuggestion: true,
+    });
 
-  if (!result) return c.json({ error: 'Transaction not found' }, 404);
-  return c.json(result);
+    if (!result) return c.json({ error: 'Transaction not found' }, 404);
+    return c.json(result);
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, 403);
+  }
 });
 
 // POST /api/classification/classify — L2: set authoritative coa_code
@@ -135,13 +200,14 @@ classificationRoutes.post('/api/classification/classify', async (c) => {
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
   const userId = c.get('userId');
-  const { transactionId, coaCode, confidence, reason } = await c.req.json();
 
-  if (!transactionId || !coaCode) {
-    return c.json({ error: 'transactionId and coaCode are required' }, 400);
+  const parsed = classifyBodySchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
   }
+  const { transactionId, coaCode, confidence, reason } = parsed.data;
 
-  // Validate COA code exists
+  // Validate COA code exists (tenant-specific or global)
   const account = await storage.getChartOfAccountByCode(coaCode, tenantId);
   if (!account) {
     return c.json({ error: `COA code ${coaCode} not found` }, 400);
@@ -174,11 +240,12 @@ classificationRoutes.post('/api/classification/reconcile', async (c) => {
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
   const userId = c.get('userId');
-  const { transactionId } = await c.req.json();
 
-  if (!transactionId) {
-    return c.json({ error: 'transactionId is required' }, 400);
+  const parsed = reconcileBodySchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
   }
+  const { transactionId } = parsed.data;
 
   try {
     const result = await storage.reconcileTransaction(transactionId, tenantId, userId);
@@ -200,10 +267,13 @@ classificationRoutes.post('/api/classification/reconcile', async (c) => {
 classificationRoutes.post('/api/classification/batch-suggest', async (c) => {
   const storage = c.get('storage');
   const tenantId = c.get('tenantId');
-  const userId = c.get('userId');
-  const limit = parseInt(c.req.query('limit') || '100', 10);
 
-  const txns = await storage.getUnclassifiedTransactions(tenantId, limit);
+  const limitParsed = batchLimitQuerySchema.safeParse(c.req.query('limit'));
+  if (!limitParsed.success) {
+    return c.json({ error: 'invalid_limit', message: 'limit must be an integer between 1 and 500' }, 400);
+  }
+
+  const txns = await storage.getUnclassifiedTransactions(tenantId, limitParsed.data);
   let suggested = 0;
 
   for (const tx of txns) {
@@ -211,24 +281,30 @@ classificationRoutes.post('/api/classification/batch-suggest', async (c) => {
     if (tx.suggestedCoaCode) continue;
 
     const code = findAccountCode(tx.description, tx.category ?? undefined);
-    await storage.classifyTransaction(tx.id, tenantId, code, {
-      actorId: 'auto:keyword-match',
-      actorType: 'system',
-      trustLevel: 'L1',
-      confidence: code === '9010' ? '0.100' : '0.700',
-      reason: `Keyword match from description/category`,
-      isSuggestion: true,
-    });
-    suggested++;
+    try {
+      await storage.classifyTransaction(tx.id, tenantId, code, {
+        actorId: 'auto:keyword-match',
+        actorType: 'system',
+        trustLevel: 'L1',
+        confidence: code === '9010' ? '0.100' : '0.700',
+        reason: `Keyword match from description/category`,
+        isSuggestion: true,
+      });
+      suggested++;
+    } catch {
+      // Skip locked/reconciled rows; continue with the rest
+      continue;
+    }
   }
 
   return c.json({ processed: txns.length, suggested });
 });
 
-// GET /api/classification/audit/:transactionId — audit trail for a transaction
+// GET /api/classification/audit/:transactionId — audit trail for a transaction (tenant-scoped)
 classificationRoutes.get('/api/classification/audit/:transactionId', async (c) => {
   const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
   const transactionId = c.req.param('transactionId');
-  const audit = await storage.getClassificationAudit(transactionId);
+  const audit = await storage.getClassificationAudit(transactionId, tenantId);
   return c.json(audit);
 });

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -1,0 +1,234 @@
+import { Hono } from 'hono';
+import type { HonoEnv } from '../env';
+import { ledgerLog } from '../lib/ledger-client';
+import { findAccountCode } from '../../database/chart-of-accounts';
+
+export const classificationRoutes = new Hono<HonoEnv>();
+
+// GET /api/coa — list Chart of Accounts for current tenant (includes global defaults)
+classificationRoutes.get('/api/coa', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const accounts = await storage.getChartOfAccounts(tenantId);
+  return c.json(accounts);
+});
+
+// GET /api/coa/global — list global (template) accounts only
+classificationRoutes.get('/api/coa/global', async (c) => {
+  const storage = c.get('storage');
+  const accounts = await storage.getGlobalChartOfAccounts();
+  return c.json(accounts);
+});
+
+// POST /api/coa — create a tenant-specific COA account (L4 only)
+classificationRoutes.post('/api/coa', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const body = await c.req.json();
+
+  const { code, name, type, subtype, description, scheduleELine, taxDeductible, parentCode } = body;
+  if (!code || !name || !type) {
+    return c.json({ error: 'code, name, and type are required' }, 400);
+  }
+
+  const existing = await storage.getChartOfAccountByCode(code, tenantId);
+  if (existing && existing.tenantId === tenantId) {
+    return c.json({ error: `Account code ${code} already exists for this tenant` }, 409);
+  }
+
+  const userId = c.get('userId');
+  const account = await storage.createChartOfAccount({
+    tenantId,
+    code,
+    name,
+    type,
+    subtype: subtype ?? null,
+    description: description ?? null,
+    scheduleELine: scheduleELine ?? null,
+    taxDeductible: taxDeductible ?? false,
+    parentCode: parentCode ?? null,
+    isActive: true,
+    modifiedBy: userId,
+  });
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'coa.create',
+    metadata: { tenantId, code, name, type, actorId: userId },
+  }, c.env);
+
+  return c.json(account, 201);
+});
+
+// PATCH /api/coa/:id — update a COA account (L4 only)
+classificationRoutes.patch('/api/coa/:id', async (c) => {
+  const storage = c.get('storage');
+  const id = c.req.param('id');
+  const body = await c.req.json();
+  const userId = c.get('userId');
+
+  const account = await storage.updateChartOfAccount(id, {
+    ...body,
+    modifiedBy: userId,
+  });
+
+  if (!account) return c.json({ error: 'Account not found' }, 404);
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'coa.update',
+    metadata: { id, changes: Object.keys(body), actorId: userId },
+  }, c.env);
+
+  return c.json(account);
+});
+
+// GET /api/classification/stats — classification progress for current tenant
+classificationRoutes.get('/api/classification/stats', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const stats = await storage.getClassificationStats(tenantId);
+  const total = Number(stats.total);
+  const classified = Number(stats.classified);
+  return c.json({
+    ...stats,
+    unclassified: total - classified,
+    classifiedPct: total > 0 ? Math.round((classified / total) * 100) : 0,
+  });
+});
+
+// GET /api/classification/unclassified — transactions needing classification
+classificationRoutes.get('/api/classification/unclassified', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const limit = parseInt(c.req.query('limit') || '50', 10);
+  const txns = await storage.getUnclassifiedTransactions(tenantId, limit);
+  return c.json(txns);
+});
+
+// POST /api/classification/suggest — L1: AI/keyword suggestion (does NOT set authoritative coa_code)
+classificationRoutes.post('/api/classification/suggest', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const { transactionId, coaCode, confidence, reason } = await c.req.json();
+
+  if (!transactionId || !coaCode) {
+    return c.json({ error: 'transactionId and coaCode are required' }, 400);
+  }
+
+  const result = await storage.classifyTransaction(transactionId, tenantId, coaCode, {
+    actorId: userId,
+    actorType: 'user',
+    trustLevel: 'L1',
+    confidence,
+    reason,
+    isSuggestion: true,
+  });
+
+  if (!result) return c.json({ error: 'Transaction not found' }, 404);
+  return c.json(result);
+});
+
+// POST /api/classification/classify — L2: set authoritative coa_code
+classificationRoutes.post('/api/classification/classify', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const { transactionId, coaCode, confidence, reason } = await c.req.json();
+
+  if (!transactionId || !coaCode) {
+    return c.json({ error: 'transactionId and coaCode are required' }, 400);
+  }
+
+  // Validate COA code exists
+  const account = await storage.getChartOfAccountByCode(coaCode, tenantId);
+  if (!account) {
+    return c.json({ error: `COA code ${coaCode} not found` }, 400);
+  }
+
+  try {
+    const result = await storage.classifyTransaction(transactionId, tenantId, coaCode, {
+      actorId: userId,
+      actorType: 'user',
+      trustLevel: 'L2',
+      confidence,
+      reason,
+    });
+    if (!result) return c.json({ error: 'Transaction not found' }, 404);
+
+    ledgerLog(c, {
+      entityType: 'audit',
+      action: 'classification.classify',
+      metadata: { transactionId, coaCode, actorId: userId },
+    }, c.env);
+
+    return c.json(result);
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, 403);
+  }
+});
+
+// POST /api/classification/reconcile — L3: lock a classified transaction
+classificationRoutes.post('/api/classification/reconcile', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const { transactionId } = await c.req.json();
+
+  if (!transactionId) {
+    return c.json({ error: 'transactionId is required' }, 400);
+  }
+
+  try {
+    const result = await storage.reconcileTransaction(transactionId, tenantId, userId);
+    if (!result) return c.json({ error: 'Transaction not found' }, 404);
+
+    ledgerLog(c, {
+      entityType: 'audit',
+      action: 'classification.reconcile',
+      metadata: { transactionId, actorId: userId },
+    }, c.env);
+
+    return c.json(result);
+  } catch (err) {
+    return c.json({ error: (err as Error).message }, 403);
+  }
+});
+
+// POST /api/classification/batch-suggest — L1: auto-suggest COA codes for unclassified transactions
+classificationRoutes.post('/api/classification/batch-suggest', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+  const limit = parseInt(c.req.query('limit') || '100', 10);
+
+  const txns = await storage.getUnclassifiedTransactions(tenantId, limit);
+  let suggested = 0;
+
+  for (const tx of txns) {
+    // Skip if already has a suggestion
+    if (tx.suggestedCoaCode) continue;
+
+    const code = findAccountCode(tx.description, tx.category ?? undefined);
+    await storage.classifyTransaction(tx.id, tenantId, code, {
+      actorId: 'auto:keyword-match',
+      actorType: 'system',
+      trustLevel: 'L1',
+      confidence: code === '9010' ? '0.100' : '0.700',
+      reason: `Keyword match from description/category`,
+      isSuggestion: true,
+    });
+    suggested++;
+  }
+
+  return c.json({ processed: txns.length, suggested });
+});
+
+// GET /api/classification/audit/:transactionId — audit trail for a transaction
+classificationRoutes.get('/api/classification/audit/:transactionId', async (c) => {
+  const storage = c.get('storage');
+  const transactionId = c.req.param('transactionId');
+  const audit = await storage.getClassificationAudit(transactionId);
+  return c.json(audit);
+});

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -3,8 +3,27 @@ import { z } from 'zod';
 import type { HonoEnv } from '../env';
 import { ledgerLog } from '../lib/ledger-client';
 import { findAccountCode } from '../../database/chart-of-accounts';
+import { ClassificationError } from '../storage/system';
 
 export const classificationRoutes = new Hono<HonoEnv>();
+
+/**
+ * Map a ClassificationError to a stable HTTP response.
+ * Unknown errors are re-thrown to hit the shared error handler (500).
+ */
+function mapClassificationError(err: unknown, c: any): Response {
+  if (err instanceof ClassificationError) {
+    switch (err.code) {
+      case 'reconciled_locked':
+        return c.json({ error: 'reconciled_locked', message: err.message }, 403);
+      case 'not_classified':
+        return c.json({ error: 'not_classified', message: err.message }, 400);
+      case 'transaction_not_found':
+        return c.json({ error: 'not_found', message: err.message }, 404);
+    }
+  }
+  throw err;
+}
 
 // Roles permitted to modify the Chart of Accounts (L4 Govern).
 // Only tenant owners and admins can add/edit/retire COA accounts.
@@ -178,6 +197,12 @@ classificationRoutes.post('/api/classification/suggest', async (c) => {
   }
   const { transactionId, coaCode, confidence, reason } = parsed.data;
 
+  // Validate COA code exists — prevents dangling suggestions that can never be resolved
+  const account = await storage.getChartOfAccountByCode(coaCode, tenantId);
+  if (!account) {
+    return c.json({ error: `COA code ${coaCode} not found` }, 400);
+  }
+
   try {
     const result = await storage.classifyTransaction(transactionId, tenantId, coaCode, {
       actorId: userId,
@@ -191,7 +216,7 @@ classificationRoutes.post('/api/classification/suggest', async (c) => {
     if (!result) return c.json({ error: 'Transaction not found' }, 404);
     return c.json(result);
   } catch (err) {
-    return c.json({ error: (err as Error).message }, 403);
+    return mapClassificationError(err, c);
   }
 });
 
@@ -231,7 +256,7 @@ classificationRoutes.post('/api/classification/classify', async (c) => {
 
     return c.json(result);
   } catch (err) {
-    return c.json({ error: (err as Error).message }, 403);
+    return mapClassificationError(err, c);
   }
 });
 
@@ -259,7 +284,7 @@ classificationRoutes.post('/api/classification/reconcile', async (c) => {
 
     return c.json(result);
   } catch (err) {
-    return c.json({ error: (err as Error).message }, 403);
+    return mapClassificationError(err, c);
   }
 });
 
@@ -291,9 +316,13 @@ classificationRoutes.post('/api/classification/batch-suggest', async (c) => {
         isSuggestion: true,
       });
       suggested++;
-    } catch {
-      // Skip locked/reconciled rows; continue with the rest
-      continue;
+    } catch (err) {
+      // Skip reconciled rows only — other errors should propagate so we
+      // don't silently hide bugs like DB outages behind a batch endpoint.
+      if (err instanceof ClassificationError && err.code === 'reconciled_locked') {
+        continue;
+      }
+      throw err;
     }
   }
 

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { HonoEnv } from '../env';
 import { ledgerLog } from '../lib/ledger-client';
+import { findAccountCode } from '../../database/chart-of-accounts';
 
 export const importRoutes = new Hono<HonoEnv>();
 
@@ -129,6 +130,10 @@ importRoutes.post('/api/import/turbotenant', async (c) => {
     );
 
     try {
+      // L0 ingest: auto-suggest COA code via keyword matching
+      const suggestedCode = findAccountCode(row.description, row.category);
+      const isSuspense = suggestedCode === '9010';
+
       await storage.createTransaction({
         tenantId,
         accountId,
@@ -140,6 +145,8 @@ importRoutes.post('/api/import/turbotenant', async (c) => {
         payee: row.tenantName || null,
         propertyId: matchedProperty?.id || null,
         externalId,
+        suggestedCoaCode: suggestedCode,
+        classificationConfidence: isSuspense ? '0.100' : '0.700',
         metadata: { source: 'turbotenant', reference: row.reference },
       });
       imported++;

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -913,13 +913,33 @@ export class SystemStorage {
     return row;
   }
 
-  async updateChartOfAccount(id: string, data: Partial<typeof schema.chartOfAccounts.$inferInsert>) {
+  async updateChartOfAccount(
+    id: string,
+    tenantId: string,
+    data: Partial<typeof schema.chartOfAccounts.$inferInsert>,
+  ) {
+    // Tenant-scoped: only allow updating accounts belonging to this tenant.
+    // Global accounts (tenant_id IS NULL) cannot be edited via this path.
     const [row] = await this.db
       .update(schema.chartOfAccounts)
       .set({ ...data, updatedAt: new Date() })
-      .where(eq(schema.chartOfAccounts.id, id))
+      .where(and(
+        eq(schema.chartOfAccounts.id, id),
+        eq(schema.chartOfAccounts.tenantId, tenantId),
+      ))
       .returning();
     return row;
+  }
+
+  async getUserRoleForTenant(userId: string, tenantId: string): Promise<string | null> {
+    const [row] = await this.db
+      .select({ role: schema.tenantUsers.role })
+      .from(schema.tenantUsers)
+      .where(and(
+        eq(schema.tenantUsers.userId, userId),
+        eq(schema.tenantUsers.tenantId, tenantId),
+      ));
+    return row?.role ?? null;
   }
 
   // ── CLASSIFICATION (trust-path operations) ──
@@ -941,42 +961,41 @@ export class SystemStorage {
     const previousCoaCode = tx.coaCode;
     const now = new Date();
 
-    if (opts.isSuggestion) {
-      // L1: write to suggested_coa_code only
-      await this.db
-        .update(schema.transactions)
-        .set({
+    // Batch update + audit insert atomically (neon-http transaction pipelines both statements)
+    const updateSet = opts.isSuggestion
+      ? {
+          // L1: write to suggested_coa_code only
           suggestedCoaCode: coaCode,
           classificationConfidence: opts.confidence ?? null,
           updatedAt: now,
-        })
-        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
-    } else {
-      // L2+: write to authoritative coa_code
-      await this.db
-        .update(schema.transactions)
-        .set({
+        }
+      : {
+          // L2+: write to authoritative coa_code
           coaCode,
           classifiedBy: opts.actorId,
           classifiedAt: now,
           classificationConfidence: opts.confidence ?? null,
           updatedAt: now,
-        })
-        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
-    }
+        };
 
-    // Audit trail
-    await this.db.insert(schema.classificationAudit).values({
-      transactionId: txId,
-      tenantId,
-      previousCoaCode,
-      newCoaCode: coaCode,
-      action: previousCoaCode ? 'reclassify' : 'classify',
-      trustLevel: opts.trustLevel,
-      actorId: opts.actorId,
-      actorType: opts.actorType,
-      confidence: opts.confidence ?? null,
-      reason: opts.reason ?? null,
+    await this.db.transaction(async (trx) => {
+      await trx
+        .update(schema.transactions)
+        .set(updateSet)
+        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+
+      await trx.insert(schema.classificationAudit).values({
+        transactionId: txId,
+        tenantId,
+        previousCoaCode,
+        newCoaCode: coaCode,
+        action: previousCoaCode ? 'reclassify' : 'classify',
+        trustLevel: opts.trustLevel,
+        actorId: opts.actorId,
+        actorType: opts.actorType,
+        confidence: opts.confidence ?? null,
+        reason: opts.reason ?? null,
+      });
     });
 
     return this.getTransaction(txId, tenantId);
@@ -989,23 +1008,27 @@ export class SystemStorage {
   ) {
     const tx = await this.getTransaction(txId, tenantId);
     if (!tx) return undefined;
-    if (!tx.coaCode) throw new Error('Cannot reconcile — transaction has no COA classification');
+    const coaCode = tx.coaCode;
+    if (!coaCode) throw new Error('Cannot reconcile — transaction has no COA classification');
 
     const now = new Date();
-    await this.db
-      .update(schema.transactions)
-      .set({ reconciled: true, reconciledBy: actorId, reconciledAt: now, updatedAt: now })
-      .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
 
-    await this.db.insert(schema.classificationAudit).values({
-      transactionId: txId,
-      tenantId,
-      previousCoaCode: tx.coaCode,
-      newCoaCode: tx.coaCode,
-      action: 'reconcile',
-      trustLevel: 'L3',
-      actorId,
-      actorType: 'user',
+    await this.db.transaction(async (trx) => {
+      await trx
+        .update(schema.transactions)
+        .set({ reconciled: true, reconciledBy: actorId, reconciledAt: now, updatedAt: now })
+        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+
+      await trx.insert(schema.classificationAudit).values({
+        transactionId: txId,
+        tenantId,
+        previousCoaCode: coaCode,
+        newCoaCode: coaCode,
+        action: 'reconcile',
+        trustLevel: 'L3',
+        actorId,
+        actorType: 'user',
+      });
     });
 
     return this.getTransaction(txId, tenantId);
@@ -1028,11 +1051,14 @@ export class SystemStorage {
       .limit(limit);
   }
 
-  async getClassificationAudit(transactionId: string) {
+  async getClassificationAudit(transactionId: string, tenantId: string) {
     return this.db
       .select()
       .from(schema.classificationAudit)
-      .where(eq(schema.classificationAudit.transactionId, transactionId))
+      .where(and(
+        eq(schema.classificationAudit.transactionId, transactionId),
+        eq(schema.classificationAudit.tenantId, tenantId),
+      ))
       .orderBy(desc(schema.classificationAudit.createdAt));
   }
 

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -4,6 +4,24 @@ import * as schema from '../db/schema';
 
 const MS_PER_DAY = 86_400_000;
 
+/**
+ * Sentinel error thrown when a trust-path operation is rejected.
+ * Routes can catch this and map the `code` to a stable HTTP response
+ * without leaking raw exception messages for unexpected failures.
+ */
+export class ClassificationError extends Error {
+  constructor(
+    public readonly code:
+      | 'reconciled_locked'
+      | 'not_classified'
+      | 'transaction_not_found',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ClassificationError';
+  }
+}
+
 export class SystemStorage {
   constructor(private db: Database) {}
 
@@ -953,15 +971,11 @@ export class SystemStorage {
     const tx = await this.getTransaction(txId, tenantId);
     if (!tx) return undefined;
 
-    // Reconciled transactions cannot be reclassified (only L3+ can unlock)
-    if (tx.reconciled && opts.trustLevel !== 'L3' && opts.trustLevel !== 'L4') {
-      throw new Error('Transaction is reconciled — only L3/L4 can modify');
-    }
-
     const previousCoaCode = tx.coaCode;
+    const previousSuggested = tx.suggestedCoaCode;
     const now = new Date();
 
-    // Batch update + audit insert atomically (neon-http transaction pipelines both statements)
+    // Decide which fields to update
     const updateSet = opts.isSuggestion
       ? {
           // L1: write to suggested_coa_code only
@@ -978,18 +992,58 @@ export class SystemStorage {
           updatedAt: now,
         };
 
+    // Reconciled lock: L0/L1/L2 writes must reject rows that were reconciled
+    // between the initial SELECT and this UPDATE. We enforce this inside the
+    // WHERE clause of the UPDATE itself (conditional update) so concurrent
+    // reconciliations can't race us.
+    const canWriteReconciled = opts.trustLevel === 'L3' || opts.trustLevel === 'L4';
+    const whereConditions = canWriteReconciled
+      ? and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId))
+      : and(
+          eq(schema.transactions.id, txId),
+          eq(schema.transactions.tenantId, tenantId),
+          eq(schema.transactions.reconciled, false),
+        );
+
+    // Action label distinguishes suggestion vs authoritative writes
+    // so the audit trail accurately reflects the L1 path.
+    const action = opts.isSuggestion
+      ? previousSuggested
+        ? 're-suggest'
+        : 'suggest'
+      : previousCoaCode
+        ? 'reclassify'
+        : 'classify';
+
     await this.db.transaction(async (trx) => {
-      await trx
+      // Conditional update — returns the row only if the WHERE matched.
+      // If the row was already reconciled (and caller is L0/L1/L2), this
+      // returns [], letting us throw a ClassificationError and roll back
+      // the audit insert via the transaction boundary.
+      const updated = await trx
         .update(schema.transactions)
         .set(updateSet)
-        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+        .where(whereConditions)
+        .returning({ id: schema.transactions.id });
+
+      if (updated.length === 0) {
+        // Distinguish "reconciled lock triggered" vs "row vanished"
+        const current = await trx
+          .select({ id: schema.transactions.id, reconciled: schema.transactions.reconciled })
+          .from(schema.transactions)
+          .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+        if (current[0]?.reconciled) {
+          throw new ClassificationError('reconciled_locked', 'Transaction is reconciled — only L3/L4 can modify');
+        }
+        throw new ClassificationError('transaction_not_found', 'Transaction not found');
+      }
 
       await trx.insert(schema.classificationAudit).values({
         transactionId: txId,
         tenantId,
-        previousCoaCode,
+        previousCoaCode: opts.isSuggestion ? (previousSuggested ?? null) : previousCoaCode,
         newCoaCode: coaCode,
-        action: previousCoaCode ? 'reclassify' : 'classify',
+        action,
         trustLevel: opts.trustLevel,
         actorId: opts.actorId,
         actorType: opts.actorType,
@@ -1009,7 +1063,9 @@ export class SystemStorage {
     const tx = await this.getTransaction(txId, tenantId);
     if (!tx) return undefined;
     const coaCode = tx.coaCode;
-    if (!coaCode) throw new Error('Cannot reconcile — transaction has no COA classification');
+    if (!coaCode) {
+      throw new ClassificationError('not_classified', 'Cannot reconcile — transaction has no COA classification');
+    }
 
     const now = new Date();
 

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, inArray } from 'drizzle-orm';
+import { eq, and, desc, sql, inArray, isNull, asc } from 'drizzle-orm';
 import type { Database } from '../db/connection';
 import * as schema from '../db/schema';
 
@@ -870,5 +870,182 @@ export class SystemStorage {
       .values(data)
       .returning();
     return row;
+  }
+
+  // ── CHART OF ACCOUNTS ──
+
+  async getChartOfAccounts(tenantId: string) {
+    // Return tenant-specific overrides + global defaults (tenant_id IS NULL)
+    return this.db
+      .select()
+      .from(schema.chartOfAccounts)
+      .where(
+        sql`${schema.chartOfAccounts.tenantId} = ${tenantId} OR ${schema.chartOfAccounts.tenantId} IS NULL`,
+      )
+      .orderBy(asc(schema.chartOfAccounts.code));
+  }
+
+  async getGlobalChartOfAccounts() {
+    return this.db
+      .select()
+      .from(schema.chartOfAccounts)
+      .where(isNull(schema.chartOfAccounts.tenantId))
+      .orderBy(asc(schema.chartOfAccounts.code));
+  }
+
+  async getChartOfAccountByCode(code: string, tenantId: string) {
+    // Prefer tenant-specific, fall back to global
+    const [tenantAcct] = await this.db
+      .select()
+      .from(schema.chartOfAccounts)
+      .where(and(eq(schema.chartOfAccounts.code, code), eq(schema.chartOfAccounts.tenantId, tenantId)));
+    if (tenantAcct) return tenantAcct;
+
+    const [globalAcct] = await this.db
+      .select()
+      .from(schema.chartOfAccounts)
+      .where(and(eq(schema.chartOfAccounts.code, code), isNull(schema.chartOfAccounts.tenantId)));
+    return globalAcct;
+  }
+
+  async createChartOfAccount(data: typeof schema.chartOfAccounts.$inferInsert) {
+    const [row] = await this.db.insert(schema.chartOfAccounts).values(data).returning();
+    return row;
+  }
+
+  async updateChartOfAccount(id: string, data: Partial<typeof schema.chartOfAccounts.$inferInsert>) {
+    const [row] = await this.db
+      .update(schema.chartOfAccounts)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(schema.chartOfAccounts.id, id))
+      .returning();
+    return row;
+  }
+
+  // ── CLASSIFICATION (trust-path operations) ──
+
+  async classifyTransaction(
+    txId: string,
+    tenantId: string,
+    coaCode: string,
+    opts: { actorId: string; actorType: 'user' | 'agent' | 'system'; trustLevel: string; confidence?: string; reason?: string; isSuggestion?: boolean },
+  ) {
+    const tx = await this.getTransaction(txId, tenantId);
+    if (!tx) return undefined;
+
+    // Reconciled transactions cannot be reclassified (only L3+ can unlock)
+    if (tx.reconciled && opts.trustLevel !== 'L3' && opts.trustLevel !== 'L4') {
+      throw new Error('Transaction is reconciled — only L3/L4 can modify');
+    }
+
+    const previousCoaCode = tx.coaCode;
+    const now = new Date();
+
+    if (opts.isSuggestion) {
+      // L1: write to suggested_coa_code only
+      await this.db
+        .update(schema.transactions)
+        .set({
+          suggestedCoaCode: coaCode,
+          classificationConfidence: opts.confidence ?? null,
+          updatedAt: now,
+        })
+        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+    } else {
+      // L2+: write to authoritative coa_code
+      await this.db
+        .update(schema.transactions)
+        .set({
+          coaCode,
+          classifiedBy: opts.actorId,
+          classifiedAt: now,
+          classificationConfidence: opts.confidence ?? null,
+          updatedAt: now,
+        })
+        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+    }
+
+    // Audit trail
+    await this.db.insert(schema.classificationAudit).values({
+      transactionId: txId,
+      tenantId,
+      previousCoaCode,
+      newCoaCode: coaCode,
+      action: previousCoaCode ? 'reclassify' : 'classify',
+      trustLevel: opts.trustLevel,
+      actorId: opts.actorId,
+      actorType: opts.actorType,
+      confidence: opts.confidence ?? null,
+      reason: opts.reason ?? null,
+    });
+
+    return this.getTransaction(txId, tenantId);
+  }
+
+  async reconcileTransaction(
+    txId: string,
+    tenantId: string,
+    actorId: string,
+  ) {
+    const tx = await this.getTransaction(txId, tenantId);
+    if (!tx) return undefined;
+    if (!tx.coaCode) throw new Error('Cannot reconcile — transaction has no COA classification');
+
+    const now = new Date();
+    await this.db
+      .update(schema.transactions)
+      .set({ reconciled: true, reconciledBy: actorId, reconciledAt: now, updatedAt: now })
+      .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+
+    await this.db.insert(schema.classificationAudit).values({
+      transactionId: txId,
+      tenantId,
+      previousCoaCode: tx.coaCode,
+      newCoaCode: tx.coaCode,
+      action: 'reconcile',
+      trustLevel: 'L3',
+      actorId,
+      actorType: 'user',
+    });
+
+    return this.getTransaction(txId, tenantId);
+  }
+
+  async getTransaction(txId: string, tenantId: string) {
+    const [row] = await this.db
+      .select()
+      .from(schema.transactions)
+      .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+    return row;
+  }
+
+  async getUnclassifiedTransactions(tenantId: string, limit = 50) {
+    return this.db
+      .select()
+      .from(schema.transactions)
+      .where(and(eq(schema.transactions.tenantId, tenantId), isNull(schema.transactions.coaCode)))
+      .orderBy(desc(schema.transactions.date))
+      .limit(limit);
+  }
+
+  async getClassificationAudit(transactionId: string) {
+    return this.db
+      .select()
+      .from(schema.classificationAudit)
+      .where(eq(schema.classificationAudit.transactionId, transactionId))
+      .orderBy(desc(schema.classificationAudit.createdAt));
+  }
+
+  async getClassificationStats(tenantId: string) {
+    const [stats] = await this.db
+      .select({
+        total: sql<number>`count(*)`,
+        classified: sql<number>`count(${schema.transactions.coaCode})`,
+        reconciled: sql<number>`count(CASE WHEN ${schema.transactions.reconciled} = true THEN 1 END)`,
+        suggested: sql<number>`count(CASE WHEN ${schema.transactions.suggestedCoaCode} IS NOT NULL AND ${schema.transactions.coaCode} IS NULL THEN 1 END)`,
+      })
+      .from(schema.transactions)
+      .where(eq(schema.transactions.tenantId, tenantId));
+    return stats;
   }
 }


### PR DESCRIPTION
## Summary
- **10 new endpoints** for COA management and trust-path classification workflow
- **Auto-classification** at TurboTenant import (keyword-match → `suggested_coa_code`)
- **Storage layer** methods for chart_of_accounts CRUD, classification, reconciliation, and stats
- **Database applied**: `chart_of_accounts` (80 global accounts), `classification_audit`, and 7 new columns on `transactions` — all live on Neon

## Endpoints

| Endpoint | Trust Level | Purpose |
|----------|-------------|---------|
| `GET /api/coa` | — | List COA (tenant + global) |
| `GET /api/coa/global` | — | List global template accounts |
| `POST /api/coa` | L4 | Create tenant-specific account |
| `PATCH /api/coa/:id` | L4 | Update account definition |
| `GET /api/classification/stats` | — | Classification progress |
| `GET /api/classification/unclassified` | — | Transactions needing COA code |
| `POST /api/classification/suggest` | L1 | Suggest COA (writes `suggested_coa_code`) |
| `POST /api/classification/classify` | L2 | Set authoritative `coa_code` |
| `POST /api/classification/reconcile` | L3 | Lock transaction |
| `POST /api/classification/batch-suggest` | L1 | Auto-suggest via keyword match |
| `GET /api/classification/audit/:txId` | — | Audit trail |

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] 212 tests pass (26 files)
- [x] Neon schema verified: 80 COA accounts seeded, indexes created
- [ ] Manual: POST /api/import/turbotenant → verify suggested_coa_code populated
- [ ] Manual: POST /api/classification/classify → verify audit trail written
- [ ] Manual: POST /api/classification/reconcile → verify lock prevents L2 reclassification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-level transaction classification: suggestion, authoritative classification, and reconciliation with audit logging.
  * Tenant-scoped Chart of Accounts (COA) plus global COA templates; COA create/update gated by tenant roles.
  * Protected classification and COA endpoints (require authentication/context).
  * Endpoints for unclassified transactions, bulk suggestions, classification stats, and per-transaction audit trails.
  * CSV import now includes COA auto-suggestions with confidence scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->