### PR TITLE
feat: AI-assisted COA classification (GPT-4o-mini)

### DIFF
--- a/server/__tests__/classification-ai.test.ts
+++ b/server/__tests__/classification-ai.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for AI-assisted COA classification (server/lib/classification-ai.ts)
+ *
+ * Focus: fallback paths, input validation, defensive parsing.
+ * Real OpenAI calls are mocked — we do not exercise the network in unit tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { classifyBatchWithAI } from '../lib/classification-ai';
+import type { ClassifiableTransaction, CoaOption } from '../lib/classification-ai';
+
+const COA: CoaOption[] = [
+  { code: '4000', name: 'Rental Income', type: 'income' },
+  { code: '5070', name: 'Repairs', type: 'expense' },
+  { code: '5300', name: 'Mortgage Interest', type: 'expense' },
+  { code: '9010', name: 'Suspense', type: 'expense' },
+];
+
+const TX_REPAIR: ClassifiableTransaction = {
+  id: 'tx-1',
+  description: 'Home Depot #1234 — plumbing supplies',
+  amount: '-125.40',
+  category: 'Repairs',
+  date: '2026-01-15',
+};
+
+const TX_RENT: ClassifiableTransaction = {
+  id: 'tx-2',
+  description: 'Rent payment from tenant',
+  amount: '1800.00',
+  category: 'Rent',
+  date: '2026-01-01',
+};
+
+const TX_WEIRD: ClassifiableTransaction = {
+  id: 'tx-3',
+  description: 'xyz unclear merchant',
+  amount: '-42.00',
+  category: null,
+  date: '2026-01-10',
+};
+
+// Mock the OpenAI SDK at module level so any `new OpenAI(...)` inside the lib uses it
+const mockCreate = vi.fn();
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockCreate } };
+    constructor(_opts: any) {}
+  },
+}));
+
+describe('classifyBatchWithAI', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it('returns empty array for empty input', async () => {
+    const result = await classifyBatchWithAI([], COA, 'fake-key');
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to keyword match when API key is missing', async () => {
+    const result = await classifyBatchWithAI([TX_REPAIR, TX_RENT], COA, '');
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.source === 'keyword')).toBe(true);
+    // Repairs keyword should hit 5070 with confidence 0.7
+    const repair = result.find((r) => r.transactionId === 'tx-1')!;
+    expect(repair.coaCode).toBe('5070');
+    expect(repair.confidence).toBe(0.7);
+  });
+
+  it('falls back to keyword match on API error', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('API down'));
+    const result = await classifyBatchWithAI([TX_REPAIR], COA, 'fake-key');
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('keyword');
+    expect(result[0].coaCode).toBe('5070');
+  });
+
+  it('parses a valid AI response and clamps confidence', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              suggestions: [
+                { id: 'tx-1', code: '5070', confidence: 0.92, reason: 'Plumbing supplies at hardware store' },
+                { id: 'tx-2', code: '4000', confidence: 1.5, reason: 'Rent inflow' }, // out-of-range, should clamp
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const result = await classifyBatchWithAI([TX_REPAIR, TX_RENT], COA, 'fake-key');
+    expect(result).toHaveLength(2);
+
+    const repair = result.find((r) => r.transactionId === 'tx-1')!;
+    expect(repair.source).toBe('ai');
+    expect(repair.coaCode).toBe('5070');
+    expect(repair.confidence).toBe(0.92);
+
+    const rent = result.find((r) => r.transactionId === 'tx-2')!;
+    expect(rent.source).toBe('ai');
+    expect(rent.coaCode).toBe('4000');
+    expect(rent.confidence).toBe(1); // clamped
+  });
+
+  it('rejects hallucinated COA codes and falls back to keyword', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              suggestions: [
+                { id: 'tx-1', code: '9999', confidence: 0.9, reason: 'Made-up code' }, // not in COA
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const result = await classifyBatchWithAI([TX_REPAIR], COA, 'fake-key');
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('keyword'); // fell back
+    expect(result[0].coaCode).toBe('5070'); // from keyword match
+  });
+
+  it('fills gaps when AI skips a transaction', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              suggestions: [
+                // Only classifies tx-1, skips tx-3
+                { id: 'tx-1', code: '5070', confidence: 0.85, reason: 'Repairs' },
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const result = await classifyBatchWithAI([TX_REPAIR, TX_WEIRD], COA, 'fake-key');
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.transactionId === 'tx-1')!.source).toBe('ai');
+    // tx-3 fell back to keyword, which returns 9010 (suspense) for unknown descriptions
+    const weird = result.find((r) => r.transactionId === 'tx-3')!;
+    expect(weird.source).toBe('keyword');
+    expect(weird.coaCode).toBe('9010');
+    expect(weird.confidence).toBe(0.1);
+  });
+
+  it('handles malformed JSON from the model by falling back', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'not valid json {{{' } }],
+    });
+
+    const result = await classifyBatchWithAI([TX_REPAIR], COA, 'fake-key');
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('keyword');
+  });
+
+  it('handles missing choices/content by falling back', async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [] });
+    const result = await classifyBatchWithAI([TX_REPAIR], COA, 'fake-key');
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('keyword');
+  });
+
+  it('rejects batches larger than MAX_BATCH', async () => {
+    const big = Array.from({ length: 30 }, (_, i) => ({
+      ...TX_REPAIR,
+      id: `tx-${i}`,
+    }));
+    await expect(classifyBatchWithAI(big, COA, 'fake-key')).rejects.toThrow(/exceeds max/);
+  });
+});

--- a/server/lib/classification-ai.ts
+++ b/server/lib/classification-ai.ts
@@ -1,8 +1,9 @@
 /**
  * AI-assisted COA classification.
  *
- * Uses GPT-4o with structured JSON output to suggest COA codes for
- * transactions that keyword matching can't confidently classify.
+ * Uses gpt-4o-mini by default (overridable via opts.model) with structured
+ * JSON output to suggest COA codes for transactions that keyword matching
+ * can't confidently classify.
  *
  * Design notes:
  *   - Instantiates OpenAI client per-request from c.env (Workers-safe)
@@ -20,7 +21,6 @@ export interface ClassifiableTransaction {
   description: string;
   amount: string;
   category?: string | null;
-  date: Date | string;
 }
 
 export interface CoaOption {

--- a/server/lib/classification-ai.ts
+++ b/server/lib/classification-ai.ts
@@ -1,0 +1,155 @@
+/**
+ * AI-assisted COA classification.
+ *
+ * Uses GPT-4o with structured JSON output to suggest COA codes for
+ * transactions that keyword matching can't confidently classify.
+ *
+ * Design notes:
+ *   - Instantiates OpenAI client per-request from c.env (Workers-safe)
+ *   - Never writes authoritative coa_code — only suggested_coa_code (L1)
+ *   - Bounded confidence range [0, 1] returned by the model
+ *   - Always falls back to keyword match if the API call fails
+ *   - Batch size is capped to keep prompt under context limits and latency sane
+ */
+
+import OpenAI from 'openai';
+import { findAccountCode } from '../../database/chart-of-accounts';
+
+export interface ClassifiableTransaction {
+  id: string;
+  description: string;
+  amount: string;
+  category?: string | null;
+  date: Date | string;
+}
+
+export interface CoaOption {
+  code: string;
+  name: string;
+  type: string;
+  description?: string | null;
+}
+
+export interface AiSuggestion {
+  transactionId: string;
+  coaCode: string;
+  confidence: number;
+  reason: string;
+  source: 'ai' | 'keyword';
+}
+
+const MAX_BATCH = 25;
+const MODEL = 'gpt-4o-mini'; // cheaper per-tx classification; gpt-4o available via override
+
+/**
+ * Build a compact COA reference for the system prompt. We include the code,
+ * name, and type — descriptions are too noisy for batch calls.
+ */
+function buildCoaReference(coa: CoaOption[]): string {
+  return coa
+    .map((a) => `${a.code}=${a.name} (${a.type})`)
+    .join('\n');
+}
+
+/**
+ * Classify a batch of transactions via GPT-4o with structured output.
+ * Always returns exactly one suggestion per input transaction.
+ * Falls back to keyword matching on any error.
+ */
+export async function classifyBatchWithAI(
+  transactions: ClassifiableTransaction[],
+  coa: CoaOption[],
+  apiKey: string,
+  opts?: { gatewayUrl?: string; model?: string },
+): Promise<AiSuggestion[]> {
+  if (transactions.length === 0) return [];
+  if (transactions.length > MAX_BATCH) {
+    throw new Error(`Batch size ${transactions.length} exceeds max ${MAX_BATCH}`);
+  }
+
+  // Fallback path if no API key or OpenAI unavailable
+  if (!apiKey) {
+    return transactions.map((tx) => keywordFallback(tx));
+  }
+
+  const client = new OpenAI({
+    apiKey,
+    ...(opts?.gatewayUrl ? { baseURL: opts.gatewayUrl } : {}),
+  });
+
+  const coaReference = buildCoaReference(coa);
+  const txPayload = transactions.map((tx) => ({
+    id: tx.id,
+    description: tx.description.slice(0, 200), // truncate noise
+    amount: tx.amount,
+    category: tx.category ?? null,
+  }));
+
+  const system = [
+    'You are a real-estate accounting classifier.',
+    'For each transaction, pick the best COA code from the list.',
+    'Rules:',
+    '- Code must be one from the reference list (exact match).',
+    '- Use 9010 (Suspense) only when no other code fits.',
+    '- Confidence is 0.0-1.0 — only >=0.7 if you are sure.',
+    '- Reason is one short phrase (<=12 words).',
+    'Respond with JSON: { "suggestions": [{ "id": string, "code": string, "confidence": number, "reason": string }] }',
+    '',
+    'COA reference:',
+    coaReference,
+  ].join('\n');
+
+  try {
+    const response = await client.chat.completions.create({
+      model: opts?.model ?? MODEL,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: JSON.stringify({ transactions: txPayload }) },
+      ],
+      temperature: 0.1,
+      max_tokens: 2000,
+      response_format: { type: 'json_object' },
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) return transactions.map((tx) => keywordFallback(tx));
+
+    const parsed = JSON.parse(content) as {
+      suggestions?: Array<{ id?: string; code?: string; confidence?: number; reason?: string }>;
+    };
+
+    const validCodes = new Set(coa.map((a) => a.code));
+    const suggestionMap = new Map<string, AiSuggestion>();
+
+    for (const s of parsed.suggestions ?? []) {
+      if (!s.id || !s.code) continue;
+      // Reject codes not in the reference list — safer to fall back than trust a hallucination
+      if (!validCodes.has(s.code)) continue;
+      const confidence = typeof s.confidence === 'number' ? Math.max(0, Math.min(1, s.confidence)) : 0.5;
+      suggestionMap.set(s.id, {
+        transactionId: s.id,
+        coaCode: s.code,
+        confidence,
+        reason: (s.reason ?? 'AI classification').slice(0, 120),
+        source: 'ai',
+      });
+    }
+
+    // Fill gaps with keyword fallback for any transaction the model skipped or hallucinated for
+    return transactions.map((tx) => suggestionMap.get(tx.id) ?? keywordFallback(tx));
+  } catch (err) {
+    console.error('[classification-ai] OpenAI call failed, falling back to keyword match:', err);
+    return transactions.map((tx) => keywordFallback(tx));
+  }
+}
+
+function keywordFallback(tx: ClassifiableTransaction): AiSuggestion {
+  const code = findAccountCode(tx.description, tx.category ?? undefined);
+  return {
+    transactionId: tx.id,
+    coaCode: code,
+    confidence: code === '9010' ? 0.1 : 0.7,
+    reason: 'Keyword match from description',
+    source: 'keyword',
+  };
+}

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -4,6 +4,7 @@ import type { HonoEnv } from '../env';
 import { ledgerLog } from '../lib/ledger-client';
 import { findAccountCode } from '../../database/chart-of-accounts';
 import { ClassificationError } from '../storage/system';
+import { classifyBatchWithAI } from '../lib/classification-ai';
 
 export const classificationRoutes = new Hono<HonoEnv>();
 
@@ -327,6 +328,82 @@ classificationRoutes.post('/api/classification/batch-suggest', async (c) => {
   }
 
   return c.json({ processed: txns.length, suggested });
+});
+
+// POST /api/classification/ai-suggest — L1: GPT-4o-mini batch suggestion with keyword fallback
+// Writes suggested_coa_code only (never authoritative coa_code).
+// Falls back to keyword match for any transaction the model can't classify.
+classificationRoutes.post('/api/classification/ai-suggest', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+
+  const limitParsed = z.coerce.number().int().min(1).max(25).default(25).safeParse(c.req.query('limit'));
+  if (!limitParsed.success) {
+    return c.json({ error: 'invalid_limit', message: 'limit must be 1-25 (batch constraint)' }, 400);
+  }
+
+  const txns = await storage.getUnclassifiedTransactions(tenantId, limitParsed.data);
+  if (txns.length === 0) {
+    return c.json({ processed: 0, suggested: 0, aiCount: 0, keywordCount: 0 });
+  }
+
+  // Only send to AI what doesn't already have a suggestion — cheaper and respects prior human input
+  const needSuggestion = txns.filter((tx) => !tx.suggestedCoaCode);
+  if (needSuggestion.length === 0) {
+    return c.json({ processed: txns.length, suggested: 0, aiCount: 0, keywordCount: 0 });
+  }
+
+  const coa = await storage.getChartOfAccounts(tenantId);
+  const apiKey = c.env.OPENAI_API_KEY ?? '';
+
+  const suggestions = await classifyBatchWithAI(
+    needSuggestion.map((tx) => ({
+      id: tx.id,
+      description: tx.description,
+      amount: tx.amount,
+      category: tx.category,
+      date: tx.date,
+    })),
+    coa.map((a: any) => ({ code: a.code, name: a.name, type: a.type, description: a.description })),
+    apiKey,
+    { gatewayUrl: c.env.AI_GATEWAY_ENDPOINT },
+  );
+
+  let aiCount = 0;
+  let keywordCount = 0;
+  let suggested = 0;
+
+  for (const s of suggestions) {
+    try {
+      await storage.classifyTransaction(s.transactionId, tenantId, s.coaCode, {
+        actorId: s.source === 'ai' ? 'auto:openai-gpt4o-mini' : 'auto:keyword-match',
+        actorType: 'system',
+        trustLevel: 'L1',
+        confidence: s.confidence.toFixed(3),
+        reason: s.reason,
+        isSuggestion: true,
+      });
+      suggested++;
+      if (s.source === 'ai') aiCount++;
+      else keywordCount++;
+    } catch {
+      continue;
+    }
+  }
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'classification.ai-suggest',
+    metadata: { tenantId, processed: suggestions.length, aiCount, keywordCount },
+  }, c.env);
+
+  return c.json({
+    processed: suggestions.length,
+    suggested,
+    aiCount,
+    keywordCount,
+    aiAvailable: Boolean(apiKey),
+  });
 });
 
 // GET /api/classification/audit/:transactionId — audit trail for a transaction (tenant-scoped)

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -342,19 +342,22 @@ classificationRoutes.post('/api/classification/ai-suggest', async (c) => {
     return c.json({ error: 'invalid_limit', message: 'limit must be 1-25 (batch constraint)' }, 400);
   }
 
+  const apiKey = c.env.OPENAI_API_KEY ?? '';
   const txns = await storage.getUnclassifiedTransactions(tenantId, limitParsed.data);
+
+  // `processed` means "fetched and considered" — stays consistent across all branches.
+  // `suggested` means "actually wrote a new suggestion to the database".
   if (txns.length === 0) {
-    return c.json({ processed: 0, suggested: 0, aiCount: 0, keywordCount: 0 });
+    return c.json({ processed: 0, suggested: 0, aiCount: 0, keywordCount: 0, aiAvailable: Boolean(apiKey) });
   }
 
   // Only send to AI what doesn't already have a suggestion — cheaper and respects prior human input
   const needSuggestion = txns.filter((tx) => !tx.suggestedCoaCode);
   if (needSuggestion.length === 0) {
-    return c.json({ processed: txns.length, suggested: 0, aiCount: 0, keywordCount: 0 });
+    return c.json({ processed: txns.length, suggested: 0, aiCount: 0, keywordCount: 0, aiAvailable: Boolean(apiKey) });
   }
 
   const coa = await storage.getChartOfAccounts(tenantId);
-  const apiKey = c.env.OPENAI_API_KEY ?? '';
 
   const suggestions = await classifyBatchWithAI(
     needSuggestion.map((tx) => ({
@@ -362,7 +365,6 @@ classificationRoutes.post('/api/classification/ai-suggest', async (c) => {
       description: tx.description,
       amount: tx.amount,
       category: tx.category,
-      date: tx.date,
     })),
     coa.map((a: any) => ({ code: a.code, name: a.name, type: a.type, description: a.description })),
     apiKey,
@@ -386,19 +388,24 @@ classificationRoutes.post('/api/classification/ai-suggest', async (c) => {
       suggested++;
       if (s.source === 'ai') aiCount++;
       else keywordCount++;
-    } catch {
-      continue;
+    } catch (err) {
+      // Skip reconciled rows only — other errors should propagate so we
+      // don't silently hide DB/runtime failures behind a batch endpoint.
+      if (err instanceof ClassificationError && err.code === 'reconciled_locked') {
+        continue;
+      }
+      throw err;
     }
   }
 
   ledgerLog(c, {
     entityType: 'audit',
     action: 'classification.ai-suggest',
-    metadata: { tenantId, processed: suggestions.length, aiCount, keywordCount },
+    metadata: { tenantId, processed: txns.length, aiCount, keywordCount },
   }, c.env);
 
   return c.json({
-    processed: suggestions.length,
+    processed: txns.length,
     suggested,
     aiCount,
     keywordCount,


### PR DESCRIPTION
## Summary
- **New endpoint**: `POST /api/classification/ai-suggest` — batches unclassified transactions through GPT-4o-mini with structured JSON output
- **Library**: `server/lib/classification-ai.ts` — per-request OpenAI client (Workers-safe), validates codes against tenant COA, clamps confidence, gap-fills with keyword fallback
- **Defensive design**: always falls back to keyword match on API error / malformed JSON / missing key / hallucinated codes
- **9 new unit tests** covering every fallback path

**Stacked on PR #86** — merge that first.

## Behavior
| Scenario | Result |
|----------|--------|
| No `OPENAI_API_KEY` | All suggestions via keyword match |
| API error / timeout | Keyword fallback, no data loss |
| Hallucinated code (not in COA) | Keyword fallback |
| Confidence out of [0,1] | Clamped |
| Model skips a transaction | Gap-filled with keyword |
| Batch > 25 | Rejected early |

## Trust-path alignment
- Always writes `suggested_coa_code` only (L1 Suggest), never authoritative `coa_code`
- `actorId` distinguishes `auto:openai-gpt4o-mini` vs `auto:keyword-match` in audit trail
- Existing classifications never overwritten (skips transactions with prior suggestions)

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] 221 tests pass (27 files — 9 new for AI classification)
- [x] Mocked OpenAI SDK — no network in unit tests
- [ ] Manual: POST /api/classification/ai-suggest with `OPENAI_API_KEY` unset → verify keyword fallback
- [ ] Manual: POST with `OPENAI_API_KEY` set → verify audit trail records `auto:openai-gpt4o-mini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-assisted Chart of Accounts (COA) classification that suggests codes for unclassified transactions, clamps confidences, and guarantees one suggestion per transaction.
  * POST /api/classification/ai-suggest endpoint for batch suggestions (1–25), with source attribution, confidence, reason, and audit logging.
  * Automatic fallback to keyword-based matching when AI is unavailable or returns malformed/invalid results.

* **Tests**
  * Comprehensive tests covering AI parsing, fallbacks, malformed responses, skipped items, hallucinations, and batch-size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->