### PR TITLE
feat: Phase 5 ecosystem integration (5 features)

### DIFF
--- a/client/src/hooks/use-classification.ts
+++ b/client/src/hooks/use-classification.ts
@@ -88,6 +88,14 @@ export function useUnclassifiedTransactions(limit = 50) {
   });
 }
 
+export function useReconciledTransactions(limit = 50) {
+  const tenantId = useTenantId();
+  return useQuery<UnclassifiedTransaction[]>({
+    queryKey: ['/api/classification/reconciled', tenantId, limit],
+    enabled: !!tenantId,
+  });
+}
+
 export function useClassificationAudit(transactionId: string | null) {
   return useQuery<ClassificationAuditEntry[]>({
     queryKey: ['/api/classification/audit', transactionId],
@@ -189,5 +197,18 @@ export function useAiSuggest() {
         aiAvailable: boolean;
       }>,
     onSuccess: () => invalidateClassificationCache(qc),
+  });
+}
+
+/** L3 — unlock a reconciled transaction */
+export function useUnreconcileTransaction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { transactionId: string }) =>
+      apiRequest('POST', '/api/classification/unreconcile', data).then((r) => r.json()),
+    onSuccess: () => {
+      invalidateClassificationCache(qc);
+      qc.invalidateQueries({ queryKey: ['/api/classification/reconciled'] });
+    },
   });
 }

--- a/client/src/pages/Classification.tsx
+++ b/client/src/pages/Classification.tsx
@@ -3,13 +3,17 @@ import {
   useChartOfAccounts,
   useClassificationStats,
   useUnclassifiedTransactions,
+  useReconciledTransactions,
   useClassifyTransaction,
   useReconcileTransaction,
+  useUnreconcileTransaction,
   useAiSuggest,
   useBatchSuggest,
   type UnclassifiedTransaction,
   type ChartOfAccount,
 } from '@/hooks/use-classification';
+
+type TabMode = 'queue' | 'reconciled';
 
 type SortMode = 'date-desc' | 'amount-desc' | 'confidence-asc' | 'confidence-desc';
 
@@ -81,12 +85,15 @@ function compareTransactions(a: UnclassifiedTransaction, b: UnclassifiedTransact
 export default function Classification() {
   const { data: stats } = useClassificationStats();
   const { data: txns = [], isLoading } = useUnclassifiedTransactions(100);
+  const { data: reconciledTxns = [], isLoading: reconciledLoading } = useReconciledTransactions(100);
   const { data: coa = [] } = useChartOfAccounts();
   const classify = useClassifyTransaction();
   const reconcile = useReconcileTransaction();
+  const unreconcile = useUnreconcileTransaction();
   const aiSuggest = useAiSuggest();
   const batchSuggest = useBatchSuggest();
 
+  const [activeTab, setActiveTab] = useState<TabMode>('queue');
   const [sortMode, setSortMode] = useState<SortMode>('date-desc');
   const [lastResult, setLastResult] = useState<string | null>(null);
 
@@ -203,41 +210,130 @@ export default function Classification() {
         </div>
       )}
 
-      {/* Sort controls */}
-      <div className="flex items-center gap-3">
-        <label className="text-xs text-[hsl(var(--cf-text-muted))]">Sort:</label>
-        <select
-          value={sortMode}
-          onChange={(e) => setSortMode(e.target.value as SortMode)}
-          className="px-3 py-1.5 text-sm bg-[hsl(var(--cf-surface))] border border-[hsl(var(--cf-border))] rounded-md text-[hsl(var(--cf-text))]"
+      {/* Tab switcher */}
+      <div className="flex gap-1 p-1 bg-[hsl(var(--cf-raised))] rounded-lg w-fit">
+        <button
+          onClick={() => setActiveTab('queue')}
+          className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+            activeTab === 'queue'
+              ? 'bg-[hsl(var(--cf-surface))] text-[hsl(var(--cf-text))] shadow-sm'
+              : 'text-[hsl(var(--cf-text-muted))] hover:text-[hsl(var(--cf-text))]'
+          }`}
         >
-          <option value="date-desc">Most recent</option>
-          <option value="amount-desc">Largest amount</option>
-          <option value="confidence-asc">Lowest confidence first</option>
-          <option value="confidence-desc">Highest confidence first</option>
-        </select>
+          Queue ({txns.length})
+        </button>
+        <button
+          onClick={() => setActiveTab('reconciled')}
+          className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+            activeTab === 'reconciled'
+              ? 'bg-[hsl(var(--cf-surface))] text-[hsl(var(--cf-text))] shadow-sm'
+              : 'text-[hsl(var(--cf-text-muted))] hover:text-[hsl(var(--cf-text))]'
+          }`}
+        >
+          Reconciled ({reconciledTxns.length})
+        </button>
       </div>
 
-      {/* Transaction queue */}
-      {isLoading ? (
-        <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">Loading...</div>
-      ) : sortedTxns.length === 0 ? (
-        <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">
-          No unclassified transactions. Nothing to review.
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {sortedTxns.map((tx) => (
-            <TransactionRow
-              key={tx.id}
-              tx={tx}
-              coaMap={coaMap}
-              coa={coa}
-              onClassify={(code) => handleClassify(tx.id, code)}
-              onReconcile={() => handleReconcile(tx.id)}
-            />
-          ))}
-        </div>
+      {/* Queue tab */}
+      {activeTab === 'queue' && (
+        <>
+          {/* Sort controls */}
+          <div className="flex items-center gap-3">
+            <label className="text-xs text-[hsl(var(--cf-text-muted))]">Sort:</label>
+            <select
+              value={sortMode}
+              onChange={(e) => setSortMode(e.target.value as SortMode)}
+              className="px-3 py-1.5 text-sm bg-[hsl(var(--cf-surface))] border border-[hsl(var(--cf-border))] rounded-md text-[hsl(var(--cf-text))]"
+            >
+              <option value="date-desc">Most recent</option>
+              <option value="amount-desc">Largest amount</option>
+              <option value="confidence-asc">Lowest confidence first</option>
+              <option value="confidence-desc">Highest confidence first</option>
+            </select>
+          </div>
+
+          {isLoading ? (
+            <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">Loading...</div>
+          ) : sortedTxns.length === 0 ? (
+            <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">
+              No unclassified transactions. Nothing to review.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {sortedTxns.map((tx) => (
+                <TransactionRow
+                  key={tx.id}
+                  tx={tx}
+                  coaMap={coaMap}
+                  coa={coa}
+                  onClassify={(code) => handleClassify(tx.id, code)}
+                  onReconcile={() => handleReconcile(tx.id)}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Reconciled tab */}
+      {activeTab === 'reconciled' && (
+        <>
+          {reconciledLoading ? (
+            <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">Loading...</div>
+          ) : reconciledTxns.length === 0 ? (
+            <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">
+              No reconciled transactions yet.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {reconciledTxns.map((tx) => {
+                const account = tx.coaCode ? coaMap.get(tx.coaCode) : null;
+                const amount = parseFloat(tx.amount);
+                return (
+                  <div key={tx.id} className="bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] rounded-lg p-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-baseline gap-3">
+                          <span className={`text-lg font-display font-semibold ${amount >= 0 ? 'text-green-400' : 'text-[hsl(var(--cf-text))]'}`}>
+                            {formatCurrency(amount)}
+                          </span>
+                          <span className="text-xs text-[hsl(var(--cf-text-muted))]">{formatDate(tx.date)}</span>
+                          <span className="text-xs text-yellow-400">Reconciled</span>
+                        </div>
+                        <div className="text-sm text-[hsl(var(--cf-text))] mt-1 truncate">{tx.description}</div>
+                        {account && (
+                          <div className="mt-1 text-xs text-green-400">
+                            {account.code} — {account.name}
+                          </div>
+                        )}
+                        {tx.reconciledBy && (
+                          <div className="mt-1 text-[10px] text-[hsl(var(--cf-text-muted))]">
+                            by {tx.reconciledBy} on {tx.reconciledAt ? formatDate(tx.reconciledAt) : '—'}
+                          </div>
+                        )}
+                      </div>
+                      <button
+                        onClick={() => {
+                          unreconcile.mutate(
+                            { transactionId: tx.id },
+                            {
+                              onSuccess: () => setLastResult('Transaction unlocked'),
+                              onError: (err: any) => setLastResult(`Error: ${err.message}`),
+                            },
+                          );
+                        }}
+                        disabled={unreconcile.isPending}
+                        className="px-3 py-1.5 text-xs font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text))] rounded hover:bg-[hsl(var(--cf-surface))] transition-colors disabled:opacity-50 shrink-0"
+                      >
+                        Unlock
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -25,6 +25,14 @@ export default function Login() {
     return err ? (ERROR_MESSAGES[err] || err) : "";
   });
   const [loading, setLoading] = useState(false);
+  const [showEmailForm, setShowEmailForm] = useState(false);
+
+  // If there's a ChittyID-related error, expand email form as fallback
+  useEffect(() => {
+    if (error && ['auth_unavailable', 'token_exchange', 'no_account'].some(e => error.includes(e) || window.location.search.includes(e))) {
+      setShowEmailForm(true);
+    }
+  }, [error]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -69,57 +77,76 @@ export default function Login() {
             <div className="text-xs text-rose-400 bg-rose-400/10 rounded px-3 py-2">{error}</div>
           )}
 
+          {/* Primary: ChittyID SSO */}
           <a
             href="/api/auth/chittyid/authorize"
-            className="flex items-center justify-center gap-2 w-full h-9 rounded-md bg-[hsl(var(--cf-surface))] border border-[hsl(var(--cf-border-subtle))] text-sm font-medium text-[hsl(var(--cf-text))] hover:bg-[hsl(var(--cf-surface-hover))] transition-colors"
+            className="flex items-center justify-center gap-2 w-full h-10 rounded-md bg-lime-500 hover:bg-lime-600 text-black text-sm font-medium transition-colors"
           >
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
-              <rect width="16" height="16" rx="3" fill="#667eea"/>
-              <text x="8" y="12" textAnchor="middle" fontSize="10" fontWeight="700" fill="white">ID</text>
+              <rect width="16" height="16" rx="3" fill="#1a1a1a"/>
+              <text x="8" y="12" textAnchor="middle" fontSize="10" fontWeight="700" fill="#84cc16">ID</text>
             </svg>
             Sign in with ChittyID
           </a>
 
-          <div className="flex items-center gap-3">
-            <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
-            <span className="text-[10px] text-[hsl(var(--cf-text-muted))] uppercase tracking-wider">or</span>
-            <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
-          </div>
+          <p className="text-[10px] text-[hsl(var(--cf-text-muted))] text-center">
+            Recommended — single sign-on across all ChittyOS services
+          </p>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1.5">
-              <Label htmlFor="email" className="text-xs text-[hsl(var(--cf-text-secondary))]">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="h-9 text-sm"
-                placeholder="you@example.com"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="password" className="text-xs text-[hsl(var(--cf-text-secondary))]">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="h-9 text-sm"
-              />
-            </div>
-
-            <Button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-lime-500 hover:bg-lime-600 text-black font-medium h-9 text-sm"
+          {/* Collapsible email/password fallback */}
+          {!showEmailForm ? (
+            <button
+              onClick={() => setShowEmailForm(true)}
+              className="flex items-center justify-center gap-2 w-full text-[10px] text-[hsl(var(--cf-text-muted))] hover:text-[hsl(var(--cf-text))] transition-colors pt-2"
             >
-              {loading ? "Signing in..." : "Sign In"}
-            </Button>
-          </form>
+              <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
+              <span>Use email &amp; password instead</span>
+              <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
+            </button>
+          ) : (
+            <>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
+                <span className="text-[10px] text-[hsl(var(--cf-text-muted))] uppercase tracking-wider">or email</span>
+                <div className="flex-1 h-px bg-[hsl(var(--cf-border-subtle))]" />
+              </div>
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="email" className="text-xs text-[hsl(var(--cf-text-secondary))]">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    className="h-9 text-sm"
+                    placeholder="you@example.com"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="password" className="text-xs text-[hsl(var(--cf-text-secondary))]">Password</Label>
+                  <Input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    className="h-9 text-sm"
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full bg-[hsl(var(--cf-surface))] hover:bg-[hsl(var(--cf-surface-hover))] border border-[hsl(var(--cf-border-subtle))] text-[hsl(var(--cf-text))] font-medium h-9 text-sm"
+                >
+                  {loading ? "Signing in..." : "Sign In with Email"}
+                </Button>
+              </form>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/database/schema-registry-payload.json
+++ b/database/schema-registry-payload.json
@@ -1,0 +1,60 @@
+{
+  "database": "chittyfinance",
+  "description": "ChittyFinance multi-tenant financial management platform — COA, classification, and property accounting",
+  "owner": "chittyfinance",
+  "tables": [
+    {
+      "name": "chart_of_accounts",
+      "description": "REI Chart of Accounts with tenant-specific overrides. NULL tenant_id = global default (80 seeded).",
+      "columns": {
+        "id": { "type": "uuid", "primaryKey": true, "default": "gen_random_uuid()" },
+        "tenant_id": { "type": "uuid", "nullable": true, "references": "tenants.id", "description": "NULL = global default template" },
+        "code": { "type": "text", "nullable": false, "description": "4-digit account code (e.g. 5070)" },
+        "name": { "type": "text", "nullable": false },
+        "type": { "type": "text", "nullable": false, "enum": ["asset", "liability", "equity", "income", "expense"] },
+        "subtype": { "type": "text", "nullable": true, "enum": ["cash", "receivable", "fixed", "contra", "current", "long-term", "capital", "suspense", "non-deductible"] },
+        "description": { "type": "text", "nullable": true },
+        "schedule_e_line": { "type": "text", "nullable": true, "description": "IRS Schedule E line reference (e.g. Line 14)" },
+        "tax_deductible": { "type": "boolean", "nullable": false, "default": false },
+        "parent_code": { "type": "text", "nullable": true, "description": "Hierarchical grouping (e.g. 5100 → parent of 5110)" },
+        "is_active": { "type": "boolean", "nullable": false, "default": true },
+        "effective_date": { "type": "timestamp", "nullable": true },
+        "modified_by": { "type": "text", "nullable": true, "description": "L4 auditor who last changed this" },
+        "metadata": { "type": "jsonb", "nullable": true, "description": "Keywords, aliases for keyword matching" },
+        "created_at": { "type": "timestamp", "nullable": false, "default": "now()" },
+        "updated_at": { "type": "timestamp", "nullable": false, "default": "now()" }
+      },
+      "indexes": [
+        { "name": "coa_tenant_idx", "columns": ["tenant_id"] },
+        { "name": "coa_code_idx", "columns": ["code"] },
+        { "name": "coa_type_idx", "columns": ["type"] },
+        { "name": "coa_tenant_code_idx", "columns": ["tenant_id", "code"], "unique": true }
+      ]
+    },
+    {
+      "name": "classification_audit",
+      "description": "Immutable audit trail for every COA classification change. Actions: suggest, re-suggest, classify, reclassify, reconcile, unreconcile.",
+      "columns": {
+        "id": { "type": "uuid", "primaryKey": true, "default": "gen_random_uuid()" },
+        "transaction_id": { "type": "uuid", "nullable": false, "references": "transactions.id" },
+        "tenant_id": { "type": "uuid", "nullable": false, "references": "tenants.id", "description": "Denormalized for tenant-scoped queries" },
+        "previous_coa_code": { "type": "text", "nullable": true },
+        "new_coa_code": { "type": "text", "nullable": false },
+        "action": { "type": "text", "nullable": false, "enum": ["suggest", "re-suggest", "classify", "reclassify", "reconcile", "unreconcile"] },
+        "trust_level": { "type": "text", "nullable": false, "enum": ["L0", "L1", "L2", "L3", "L4"] },
+        "actor_id": { "type": "text", "nullable": false, "description": "User UUID, agent session ID, or 'auto:keyword-match'/'auto:openai-gpt4o-mini'" },
+        "actor_type": { "type": "text", "nullable": false, "enum": ["user", "agent", "system"] },
+        "confidence": { "type": "numeric(4,3)", "nullable": true, "description": "0.000-1.000 at time of action" },
+        "reason": { "type": "text", "nullable": true },
+        "metadata": { "type": "jsonb", "nullable": true },
+        "created_at": { "type": "timestamp", "nullable": false, "default": "now()" }
+      },
+      "indexes": [
+        { "name": "classification_audit_transaction_idx", "columns": ["transaction_id"] },
+        { "name": "classification_audit_tenant_idx", "columns": ["tenant_id"] },
+        { "name": "classification_audit_actor_idx", "columns": ["actor_id"] },
+        { "name": "classification_audit_trust_level_idx", "columns": ["trust_level"] }
+      ]
+    }
+  ]
+}

--- a/server/lib/chittychronicle.ts
+++ b/server/lib/chittychronicle.ts
@@ -1,0 +1,122 @@
+/**
+ * ChittyChronicle fire-and-forget audit logger.
+ *
+ * Posts classification/COA events to chronicle.chitty.cc for immutable audit.
+ * Workers-native — takes `env` not `process.env`. Never blocks the caller;
+ * errors are logged and swallowed (chronicle.chitty.cc API returns 404 for
+ * now — routes not yet deployed; this client is ready when they are).
+ */
+
+const CHRONICLE_BASE = 'https://chronicle.chitty.cc';
+const TIMEOUT_MS = 3000;
+
+export interface ChronicleEvent {
+  eventType: string; // 'classification.classify', 'classification.reconcile', 'coa.create', etc.
+  entityId: string; // transaction or COA account ID
+  entityType: string; // 'transaction', 'chart_of_accounts'
+  action: string; // 'classify', 'reconcile', 'create', 'update', 'unreconcile'
+  actor?: {
+    id: string;
+    type: 'user' | 'agent' | 'system';
+  };
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Post an event to ChittyChronicle. Fire-and-forget — never throws,
+ * never blocks. Returns true if the post succeeded (2xx), false otherwise.
+ */
+export async function logToChronicle(
+  env: { CHITTY_AUTH_SERVICE_TOKEN?: string },
+  event: ChronicleEvent,
+): Promise<boolean> {
+  try {
+    const body = {
+      ...event,
+      source: 'chittyfinance',
+      timestamp: new Date().toISOString(),
+    };
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (env.CHITTY_AUTH_SERVICE_TOKEN) {
+      headers['Authorization'] = `Bearer ${env.CHITTY_AUTH_SERVICE_TOKEN}`;
+    }
+
+    const response = await fetch(`${CHRONICLE_BASE}/api/events`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      // Expected 404 until Chronicle deploys its event ingestion routes
+      if (response.status !== 404) {
+        console.warn(`[chittychronicle] POST /api/events returned ${response.status}`);
+      }
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    console.warn('[chittychronicle] logToChronicle failed:', (err as Error).message);
+    return false;
+  }
+}
+
+/**
+ * Convenience: log a classification event (classify, reconcile, unreconcile).
+ */
+export function logClassificationEvent(
+  env: { CHITTY_AUTH_SERVICE_TOKEN?: string },
+  params: {
+    transactionId: string;
+    tenantId: string;
+    action: string; // classify, reclassify, reconcile, unreconcile, suggest
+    coaCode: string;
+    actorId: string;
+    actorType: 'user' | 'agent' | 'system';
+    previousCoaCode?: string | null;
+    confidence?: string | null;
+  },
+): Promise<boolean> {
+  return logToChronicle(env, {
+    eventType: `classification.${params.action}`,
+    entityId: params.transactionId,
+    entityType: 'transaction',
+    action: params.action,
+    actor: { id: params.actorId, type: params.actorType },
+    before: params.previousCoaCode ? { coaCode: params.previousCoaCode } : undefined,
+    after: { coaCode: params.coaCode, confidence: params.confidence },
+    metadata: { tenantId: params.tenantId },
+  });
+}
+
+/**
+ * Convenience: log a COA mutation event (create, update, deactivate).
+ */
+export function logCoaEvent(
+  env: { CHITTY_AUTH_SERVICE_TOKEN?: string },
+  params: {
+    accountId: string;
+    tenantId: string;
+    action: 'create' | 'update' | 'deactivate' | 'activate';
+    code: string;
+    actorId: string;
+    changes?: Record<string, unknown>;
+  },
+): Promise<boolean> {
+  return logToChronicle(env, {
+    eventType: `coa.${params.action}`,
+    entityId: params.accountId,
+    entityType: 'chart_of_accounts',
+    action: params.action,
+    actor: { id: params.actorId, type: 'user' },
+    after: { code: params.code, changes: params.changes },
+    metadata: { tenantId: params.tenantId },
+  });
+}

--- a/server/routes/classification.ts
+++ b/server/routes/classification.ts
@@ -5,6 +5,7 @@ import { ledgerLog } from '../lib/ledger-client';
 import { findAccountCode } from '../../database/chart-of-accounts';
 import { ClassificationError } from '../storage/system';
 import { classifyBatchWithAI } from '../lib/classification-ai';
+import { logClassificationEvent, logCoaEvent } from '../lib/chittychronicle';
 
 export const classificationRoutes = new Hono<HonoEnv>();
 
@@ -125,6 +126,10 @@ classificationRoutes.post('/api/coa', async (c) => {
     action: 'coa.create',
     metadata: { tenantId, code: body.code, name: body.name, type: body.type, actorId: userId },
   }, c.env);
+
+  logCoaEvent(c.env, {
+    accountId: account.id, tenantId, action: 'create', code: body.code, actorId: userId,
+  });
 
   return c.json(account, 201);
 });
@@ -255,6 +260,12 @@ classificationRoutes.post('/api/classification/classify', async (c) => {
       metadata: { transactionId, coaCode, actorId: userId },
     }, c.env);
 
+    // Fire-and-forget Chronicle audit (never blocks response)
+    logClassificationEvent(c.env, {
+      transactionId, tenantId, action: 'classify', coaCode,
+      actorId: userId, actorType: 'user', confidence,
+    });
+
     return c.json(result);
   } catch (err) {
     return mapClassificationError(err, c);
@@ -282,6 +293,11 @@ classificationRoutes.post('/api/classification/reconcile', async (c) => {
       action: 'classification.reconcile',
       metadata: { transactionId, actorId: userId },
     }, c.env);
+
+    logClassificationEvent(c.env, {
+      transactionId, tenantId, action: 'reconcile',
+      coaCode: result.coaCode ?? '', actorId: userId, actorType: 'user',
+    });
 
     return c.json(result);
   } catch (err) {
@@ -411,6 +427,46 @@ classificationRoutes.post('/api/classification/ai-suggest', async (c) => {
     keywordCount,
     aiAvailable: Boolean(apiKey),
   });
+});
+
+// GET /api/classification/reconciled — list reconciled (locked) transactions
+classificationRoutes.get('/api/classification/reconciled', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const limitParsed = limitQuerySchema.safeParse(c.req.query('limit'));
+  if (!limitParsed.success) {
+    return c.json({ error: 'invalid_limit', message: 'limit must be 1-500' }, 400);
+  }
+  const txns = await storage.getReconciledTransactions(tenantId, limitParsed.data);
+  return c.json(txns);
+});
+
+// POST /api/classification/unreconcile — L3: unlock a reconciled transaction
+classificationRoutes.post('/api/classification/unreconcile', async (c) => {
+  const storage = c.get('storage');
+  const tenantId = c.get('tenantId');
+  const userId = c.get('userId');
+
+  const parsed = reconcileBodySchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_body', details: parsed.error.flatten() }, 400);
+  }
+
+  const result = await storage.unreconciledTransaction(parsed.data.transactionId, tenantId, userId);
+  if (!result) return c.json({ error: 'Transaction not found' }, 404);
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'classification.unreconcile',
+    metadata: { transactionId: parsed.data.transactionId, actorId: userId },
+  }, c.env);
+
+  logClassificationEvent(c.env, {
+    transactionId: parsed.data.transactionId, tenantId, action: 'unreconcile',
+    coaCode: result.coaCode ?? '', actorId: userId, actorType: 'user',
+  });
+
+  return c.json(result);
 });
 
 // GET /api/classification/audit/:transactionId — audit trail for a transaction (tenant-scoped)

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -41,6 +41,34 @@ const mercuryWebhookEnvelopeSchema = z.object({
     .optional(),
 });
 
+/**
+ * Wave webhook transaction payload.
+ *
+ * Wave uses GraphQL push notifications. ChittyConnect normalizes to this
+ * shape before forwarding, same as Mercury.
+ */
+const waveTransactionSchema = z.object({
+  tenantId: z.string().uuid(),
+  accountId: z.string().uuid(),
+  waveTransactionId: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  category: z.string().optional().nullable(),
+  postedAt: z.string(),
+  payee: z.string().optional().nullable(),
+});
+
+const waveWebhookEnvelopeSchema = z.object({
+  id: z.string().optional(),
+  eventId: z.string().optional(),
+  type: z.string().optional(),
+  data: z
+    .object({
+      transaction: waveTransactionSchema.optional(),
+    })
+    .optional(),
+});
+
 // POST /api/webhooks/stripe — Stripe webhook endpoint
 webhookRoutes.post('/api/webhooks/stripe', async (c) => {
   const secret = c.env.STRIPE_WEBHOOK_SECRET;
@@ -221,4 +249,94 @@ webhookRoutes.post('/api/webhooks/mercury', async (c) => {
     },
     201,
   );
+});
+
+// POST /api/webhooks/wave — Wave Accounting webhook with real-time classification
+// Same flow as Mercury: service-auth → zod → KV dedup → classify → ChittySchema advisory → persist
+webhookRoutes.post('/api/webhooks/wave', async (c) => {
+  const expected = c.env.CHITTY_AUTH_SERVICE_TOKEN;
+  if (!expected) return c.json({ error: 'auth_not_configured' }, 500);
+
+  const auth = c.req.header('authorization') ?? '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token || token !== expected) return c.json({ error: 'unauthorized' }, 401);
+
+  const rawBody = await c.req.json().catch(() => null);
+  const envelope = waveWebhookEnvelopeSchema.safeParse(rawBody);
+  if (!envelope.success) {
+    return c.json({ error: 'invalid_envelope', details: envelope.error.flatten() }, 400);
+  }
+
+  const eventId = c.req.header('x-event-id') || envelope.data.id || envelope.data.eventId;
+  if (!eventId) return c.json({ error: 'missing_event_id' }, 400);
+
+  const kv = c.env.FINANCE_KV;
+  const dedupKey = `webhook:wave:${eventId}`;
+  const existing = await kv.get(dedupKey);
+  if (existing) return c.json({ received: true, duplicate: true }, 202);
+  await kv.put(dedupKey, JSON.stringify(rawBody || {}), { expirationTtl: 604800 });
+
+  const tx = envelope.data.data?.transaction;
+  if (!tx) return c.json({ received: true }, 202);
+
+  const suggestedCoaCode = findAccountCode(tx.description, tx.category ?? undefined);
+  const isSuspense = suggestedCoaCode === '9010';
+  const classificationConfidence = isSuspense ? '0.100' : '0.700';
+  const externalId = `wave:${tx.waveTransactionId}`;
+
+  const schemaResult = await validateRow(c.env, 'FinancialTransactionsInsertSchema', {
+    tenantId: tx.tenantId,
+    accountId: tx.accountId,
+    amount: String(tx.amount),
+    type: tx.amount >= 0 ? 'income' : 'expense',
+    description: tx.description,
+    date: tx.postedAt,
+    externalId,
+  });
+
+  if (!schemaResult.ok && schemaResult.errors) {
+    console.warn('[webhook:wave] ChittySchema validation failed (advisory)', { eventId, errors: schemaResult.errors });
+  }
+
+  const db = createDb(c.env.DATABASE_URL);
+  const storage = new SystemStorage(db);
+
+  const dupRow = await storage.getTransactionByExternalId(externalId, tx.tenantId);
+  if (dupRow) return c.json({ received: true, duplicate: true, transactionId: dupRow.id }, 202);
+
+  const created = await storage.createTransaction({
+    tenantId: tx.tenantId,
+    accountId: tx.accountId,
+    amount: String(tx.amount),
+    type: tx.amount >= 0 ? 'income' : 'expense',
+    category: tx.category ?? null,
+    description: tx.description,
+    date: new Date(tx.postedAt),
+    payee: tx.payee ?? null,
+    externalId,
+    suggestedCoaCode,
+    classificationConfidence,
+    metadata: { source: 'wave_webhook', waveTransactionId: tx.waveTransactionId, eventId },
+  });
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'webhook.wave.transaction_ingested',
+    metadata: {
+      tenantId: tx.tenantId,
+      accountId: tx.accountId,
+      transactionId: created.id,
+      suggestedCoaCode,
+      confidence: classificationConfidence,
+      schemaAdvisory: schemaResult.advisory,
+    },
+  }, c.env);
+
+  return c.json({
+    received: true,
+    transactionId: created.id,
+    suggestedCoaCode,
+    classificationConfidence,
+    schemaAdvisory: schemaResult.advisory,
+  }, 201);
 });

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -1108,6 +1108,42 @@ export class SystemStorage {
       .limit(limit);
   }
 
+  async getReconciledTransactions(tenantId: string, limit = 50) {
+    return this.db
+      .select()
+      .from(schema.transactions)
+      .where(and(eq(schema.transactions.tenantId, tenantId), eq(schema.transactions.reconciled, true)))
+      .orderBy(desc(schema.transactions.reconciledAt))
+      .limit(limit);
+  }
+
+  async unreconciledTransaction(txId: string, tenantId: string, actorId: string) {
+    const tx = await this.getTransaction(txId, tenantId);
+    if (!tx) return undefined;
+    if (!tx.reconciled) return tx;
+
+    const now = new Date();
+    await this.db.transaction(async (trx) => {
+      await trx
+        .update(schema.transactions)
+        .set({ reconciled: false, reconciledBy: null, reconciledAt: null, updatedAt: now })
+        .where(and(eq(schema.transactions.id, txId), eq(schema.transactions.tenantId, tenantId)));
+
+      await trx.insert(schema.classificationAudit).values({
+        transactionId: txId,
+        tenantId,
+        previousCoaCode: tx.coaCode,
+        newCoaCode: tx.coaCode ?? '9010',
+        action: 'unreconcile',
+        trustLevel: 'L3',
+        actorId,
+        actorType: 'user',
+      });
+    });
+
+    return this.getTransaction(txId, tenantId);
+  }
+
   async getClassificationAudit(transactionId: string, tenantId: string) {
     return this.db
       .select()


### PR DESCRIPTION
## Summary
5 independent features completing the ChittyOS ecosystem integration for ChittyFinance's COA trust-path system.

## Features

### 1. Reconciled-row visibility
| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/classification/reconciled` | GET | List locked L3 transactions |
| `/api/classification/unreconcile` | POST | L3 unlock with full audit trail |

Classification page gains a **Queue / Reconciled** tab switcher. Reconciled tab shows each locked row with COA code, reconciled-by, and an **Unlock** button.

### 2. Wave webhook real-time classification
`POST /api/webhooks/wave` — identical flow to Mercury webhook (#90): service-auth, zod envelope, KV dedup (7-day TTL), keyword auto-classification, ChittySchema advisory, DB persist. `externalId = wave:{waveTransactionId}`.

### 3. ChittyChronicle audit logging
New `server/lib/chittychronicle.ts` — fire-and-forget, Workers-native. Posts events to `chronicle.chitty.cc/api/events`. Falls open on error (404 expected until Chronicle deploys ingestion routes). Wired into: classify (L2), reconcile (L3), unreconcile (L3), COA create (L4).

### 4. Schema registry payload
`database/schema-registry-payload.json` — complete JSON schema for `chart_of_accounts` and `classification_audit`. Ready for operator to register with schema.chitty.cc once the `chittyfinance` database namespace is added. Includes all columns, types, constraints, indexes, and enums.

### 5. ChittyID SSO as default auth
Login page redesigned: ChittyID is the primary action (lime green button, full width, "Recommended" label). Email/password collapsed by default behind a "Use email & password instead" link. Auto-expands on ChittyID errors so users fall back gracefully. Email sign-in button visually demoted to outline style.

## Test plan
- [x] TypeScript check passes (0 errors)
- [x] 253 tests pass (no regressions)
- [x] Vite build succeeds
- [ ] Manual: /classification → Reconciled tab → verify locked rows display
- [ ] Manual: /classification → Reconciled → Unlock → verify row moves back to Queue
- [ ] Manual: POST /api/webhooks/wave with test payload → verify 201 with suggestedCoaCode
- [ ] Manual: Check console for [chittychronicle] warnings (expected 404 until API deploys)
- [ ] Manual: /login → verify ChittyID button is primary, email form is collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Reconciled" transactions tab with ability to unlock reconciled transactions
  * Enhanced login flow with improved SSO presentation and conditional email fallback option
  * Added Wave Accounting webhook integration support
  * Added comprehensive audit trail for transaction classifications and chart of accounts modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->