### PR TITLE
feat: classification enhancements — bulk-accept opt-out, L3 audit trail, tenant settings

### DIFF
--- a/client/src/hooks/use-classification.ts
+++ b/client/src/hooks/use-classification.ts
@@ -200,6 +200,28 @@ export function useAiSuggest() {
   });
 }
 
+/** Tenant classification settings (bulk-accept opt-out, etc.) */
+export function useTenantSettings() {
+  const tenantId = useTenantId();
+  return useQuery<{ bulkAcceptDisabled: boolean }>({
+    queryKey: ['/api/tenants', tenantId, 'settings'],
+    queryFn: () => fetch(`/api/tenants/${tenantId}/settings`, { credentials: 'include' }).then((r) => r.json()),
+    enabled: !!tenantId,
+  });
+}
+
+export function useUpdateTenantSettings() {
+  const qc = useQueryClient();
+  const tenantId = useTenantId();
+  return useMutation({
+    mutationFn: (data: { bulkAcceptDisabled?: boolean }) =>
+      apiRequest('PATCH', `/api/tenants/${tenantId}/settings`, data).then((r) => r.json()),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['/api/tenants', tenantId, 'settings'] });
+    },
+  });
+}
+
 /** L3 — unlock a reconciled transaction */
 export function useUnreconcileTransaction() {
   const qc = useQueryClient();

--- a/client/src/hooks/use-classification.ts
+++ b/client/src/hooks/use-classification.ts
@@ -205,7 +205,7 @@ export function useTenantSettings() {
   const tenantId = useTenantId();
   return useQuery<{ bulkAcceptDisabled: boolean }>({
     queryKey: ['/api/tenants', tenantId, 'settings'],
-    queryFn: () => fetch(`/api/tenants/${tenantId}/settings`, { credentials: 'include' }).then((r) => r.json()),
+    queryFn: () => apiRequest('GET', `/api/tenants/${tenantId}/settings`).then((r) => r.json()),
     enabled: !!tenantId,
   });
 }

--- a/client/src/pages/Classification.tsx
+++ b/client/src/pages/Classification.tsx
@@ -9,6 +9,9 @@ import {
   useUnreconcileTransaction,
   useAiSuggest,
   useBatchSuggest,
+  useTenantSettings,
+  useUpdateTenantSettings,
+  useClassificationAudit,
   type UnclassifiedTransaction,
   type ChartOfAccount,
 } from '@/hooks/use-classification';
@@ -92,10 +95,14 @@ export default function Classification() {
   const unreconcile = useUnreconcileTransaction();
   const aiSuggest = useAiSuggest();
   const batchSuggest = useBatchSuggest();
+  const { data: tenantSettings } = useTenantSettings();
+  const updateSettings = useUpdateTenantSettings();
 
   const [activeTab, setActiveTab] = useState<TabMode>('queue');
   const [sortMode, setSortMode] = useState<SortMode>('date-desc');
   const [lastResult, setLastResult] = useState<string | null>(null);
+
+  const bulkAcceptDisabled = tenantSettings?.bulkAcceptDisabled ?? false;
 
   const coaMap = useMemo(() => new Map(coa.map((a) => [a.code, a])), [coa]);
   const sortedTxns = useMemo(() => [...txns].sort((a, b) => compareTransactions(a, b, sortMode)), [txns, sortMode]);
@@ -183,13 +190,15 @@ export default function Classification() {
           >
             {aiSuggest.isPending ? 'Thinking...' : 'AI Suggest (GPT)'}
           </button>
-          <button
-            onClick={handleAcceptAll}
-            disabled={classify.isPending}
-            className="px-3 py-2 text-sm font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text))] rounded-md hover:bg-[hsl(var(--cf-surface))] transition-colors disabled:opacity-50"
-          >
-            Accept High-Confidence
-          </button>
+          {!bulkAcceptDisabled && (
+            <button
+              onClick={handleAcceptAll}
+              disabled={classify.isPending}
+              className="px-3 py-2 text-sm font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text))] rounded-md hover:bg-[hsl(var(--cf-surface))] transition-colors disabled:opacity-50"
+            >
+              Accept High-Confidence
+            </button>
+          )}
         </div>
       </div>
 
@@ -278,6 +287,24 @@ export default function Classification() {
       {/* Reconciled tab */}
       {activeTab === 'reconciled' && (
         <>
+          {/* Bulk accept toggle */}
+          <div className="flex items-center gap-3 px-4 py-3 bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] rounded-lg">
+            <label className="flex items-center gap-2 text-sm text-[hsl(var(--cf-text))] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={bulkAcceptDisabled}
+                onChange={(e) => updateSettings.mutate({ bulkAcceptDisabled: e.target.checked })}
+                className="rounded border-[hsl(var(--cf-border))]"
+              />
+              Disable bulk-accept for this tenant
+            </label>
+            <span className="text-xs text-[hsl(var(--cf-text-muted))]">
+              {bulkAcceptDisabled
+                ? 'Every transaction requires individual L2 review'
+                : 'High-confidence suggestions can be bulk-accepted'}
+            </span>
+          </div>
+
           {reconciledLoading ? (
             <div className="text-center py-12 text-[hsl(var(--cf-text-muted))]">Loading...</div>
           ) : reconciledTxns.length === 0 ? (
@@ -286,51 +313,23 @@ export default function Classification() {
             </div>
           ) : (
             <div className="space-y-2">
-              {reconciledTxns.map((tx) => {
-                const account = tx.coaCode ? coaMap.get(tx.coaCode) : null;
-                const amount = parseFloat(tx.amount);
-                return (
-                  <div key={tx.id} className="bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] rounded-lg p-4">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-baseline gap-3">
-                          <span className={`text-lg font-display font-semibold ${amount >= 0 ? 'text-green-400' : 'text-[hsl(var(--cf-text))]'}`}>
-                            {formatCurrency(amount)}
-                          </span>
-                          <span className="text-xs text-[hsl(var(--cf-text-muted))]">{formatDate(tx.date)}</span>
-                          <span className="text-xs text-yellow-400">Reconciled</span>
-                        </div>
-                        <div className="text-sm text-[hsl(var(--cf-text))] mt-1 truncate">{tx.description}</div>
-                        {account && (
-                          <div className="mt-1 text-xs text-green-400">
-                            {account.code} — {account.name}
-                          </div>
-                        )}
-                        {tx.reconciledBy && (
-                          <div className="mt-1 text-[10px] text-[hsl(var(--cf-text-muted))]">
-                            by {tx.reconciledBy} on {tx.reconciledAt ? formatDate(tx.reconciledAt) : '—'}
-                          </div>
-                        )}
-                      </div>
-                      <button
-                        onClick={() => {
-                          unreconcile.mutate(
-                            { transactionId: tx.id },
-                            {
-                              onSuccess: () => setLastResult('Transaction unlocked'),
-                              onError: (err: any) => setLastResult(`Error: ${err.message}`),
-                            },
-                          );
-                        }}
-                        disabled={unreconcile.isPending}
-                        className="px-3 py-1.5 text-xs font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text))] rounded hover:bg-[hsl(var(--cf-surface))] transition-colors disabled:opacity-50 shrink-0"
-                      >
-                        Unlock
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
+              {reconciledTxns.map((tx) => (
+                <ReconciledRow
+                  key={tx.id}
+                  tx={tx}
+                  coaMap={coaMap}
+                  onUnreconcile={() => {
+                    unreconcile.mutate(
+                      { transactionId: tx.id },
+                      {
+                        onSuccess: () => setLastResult('Transaction unlocked'),
+                        onError: (err: any) => setLastResult(`Error: ${err.message}`),
+                      },
+                    );
+                  }}
+                  isUnreconciling={unreconcile.isPending}
+                />
+              ))}
             </div>
           )}
         </>
@@ -356,6 +355,98 @@ interface TransactionRowProps {
   coa: ChartOfAccount[];
   onClassify: (code: string) => void;
   onReconcile: () => void;
+}
+
+interface ReconciledRowProps {
+  tx: UnclassifiedTransaction;
+  coaMap: Map<string, ChartOfAccount>;
+  onUnreconcile: () => void;
+  isUnreconciling: boolean;
+}
+
+function ReconciledRow({ tx, coaMap, onUnreconcile, isUnreconciling }: ReconciledRowProps) {
+  const [showAudit, setShowAudit] = useState(false);
+  const { data: auditLog } = useClassificationAudit(showAudit ? tx.id : null);
+  const account = tx.coaCode ? coaMap.get(tx.coaCode) : null;
+  const amount = parseFloat(tx.amount);
+
+  return (
+    <div className="bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] rounded-lg p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-3">
+            <span className={`text-lg font-display font-semibold ${amount >= 0 ? 'text-green-400' : 'text-[hsl(var(--cf-text))]'}`}>
+              {formatCurrency(amount)}
+            </span>
+            <span className="text-xs text-[hsl(var(--cf-text-muted))]">{formatDate(tx.date)}</span>
+            <span className="text-xs text-yellow-400">Reconciled</span>
+          </div>
+          <div className="text-sm text-[hsl(var(--cf-text))] mt-1 truncate">{tx.description}</div>
+          {account && (
+            <div className="mt-1 text-xs text-green-400">
+              {account.code} — {account.name}
+            </div>
+          )}
+          <div className="mt-1 flex items-center gap-4 text-[10px] text-[hsl(var(--cf-text-muted))]">
+            {tx.classifiedBy && (
+              <span>Classified by {tx.classifiedBy}{tx.classifiedAt ? ` on ${formatDate(tx.classifiedAt)}` : ''}</span>
+            )}
+            {tx.reconciledBy && (
+              <span>Reconciled by {tx.reconciledBy}{tx.reconciledAt ? ` on ${formatDate(tx.reconciledAt)}` : ''}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5 shrink-0">
+          <button
+            onClick={() => setShowAudit(!showAudit)}
+            className="px-3 py-1.5 text-xs font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text-muted))] rounded hover:text-[hsl(var(--cf-text))] transition-colors"
+          >
+            {showAudit ? 'Hide Trail' : 'Audit Trail'}
+          </button>
+          <button
+            onClick={onUnreconcile}
+            disabled={isUnreconciling}
+            className="px-3 py-1.5 text-xs font-medium bg-[hsl(var(--cf-raised))] border border-[hsl(var(--cf-border))] text-[hsl(var(--cf-text))] rounded hover:bg-[hsl(var(--cf-surface))] transition-colors disabled:opacity-50"
+          >
+            Unlock
+          </button>
+        </div>
+      </div>
+
+      {/* Audit trail expansion */}
+      {showAudit && auditLog && auditLog.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-[hsl(var(--cf-border))] space-y-1">
+          {auditLog.map((entry) => (
+            <div key={entry.id} className="flex items-baseline gap-2 text-[10px]">
+              <span className="text-[hsl(var(--cf-text-muted))] w-[70px] shrink-0">{formatDate(entry.createdAt)}</span>
+              <span className={`w-[60px] shrink-0 ${
+                entry.action === 'reconcile' ? 'text-yellow-400' :
+                entry.action.includes('classify') ? 'text-green-400' :
+                'text-[hsl(var(--cf-text-muted))]'
+              }`}>{entry.action}</span>
+              <span className="text-[hsl(var(--cf-text))]">{entry.newCoaCode}</span>
+              {entry.previousCoaCode && (
+                <span className="text-[hsl(var(--cf-text-muted))]">(was {entry.previousCoaCode})</span>
+              )}
+              <span className="text-[hsl(var(--cf-text-muted))]">
+                {entry.trustLevel} by {entry.actorId}
+              </span>
+              {entry.confidence && (
+                <span className={confidenceColor(parseFloat(entry.confidence))}>
+                  {(parseFloat(entry.confidence) * 100).toFixed(0)}%
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {showAudit && (!auditLog || auditLog.length === 0) && (
+        <div className="mt-3 pt-3 border-t border-[hsl(var(--cf-border))] text-[10px] text-[hsl(var(--cf-text-muted))]">
+          No audit entries found
+        </div>
+      )}
+    </div>
+  );
 }
 
 function TransactionRow({ tx, coaMap, coa, onClassify, onReconcile }: TransactionRowProps) {

--- a/client/src/pages/Classification.tsx
+++ b/client/src/pages/Classification.tsx
@@ -39,6 +39,12 @@ function confidenceColor(conf: number): string {
   return 'text-red-400';
 }
 
+function auditActionColor(action: string): string {
+  if (action === 'reconcile') return 'text-yellow-400';
+  if (action.includes('classify')) return 'text-green-400';
+  return 'text-[hsl(var(--cf-text-muted))]';
+}
+
 /**
  * Trust boundary for one-click "Accept High-Confidence Suggestions".
  *
@@ -110,7 +116,10 @@ export default function Classification() {
   function handleClassify(txId: string, coaCode: string) {
     classify.mutate(
       { transactionId: txId, coaCode, reason: 'Manual classification via UI' },
-      { onSuccess: () => setLastResult(`Classified transaction as ${coaCode}`) },
+      {
+        onSuccess: () => setLastResult(`Classified transaction as ${coaCode}`),
+        onError: (err: any) => setLastResult(`Classification failed: ${err.message}`),
+      },
     );
   }
 
@@ -147,8 +156,9 @@ export default function Classification() {
       setLastResult('No candidates qualified for bulk accept');
       return;
     }
-    // Fire mutations sequentially to avoid overloading the classify endpoint
     let done = 0;
+    let failed = 0;
+    const total = candidates.length;
     for (const tx of candidates) {
       if (!tx.suggestedCoaCode) continue;
       classify.mutate(
@@ -156,7 +166,11 @@ export default function Classification() {
         {
           onSuccess: () => {
             done++;
-            if (done === candidates.length) setLastResult(`Bulk accepted ${done} transactions`);
+            if (done + failed === total) setLastResult(`Bulk: ${done} accepted${failed ? `, ${failed} failed` : ''}`);
+          },
+          onError: () => {
+            failed++;
+            if (done + failed === total) setLastResult(`Bulk: ${done} accepted, ${failed} failed`);
           },
         },
       );
@@ -293,7 +307,17 @@ export default function Classification() {
               <input
                 type="checkbox"
                 checked={bulkAcceptDisabled}
-                onChange={(e) => updateSettings.mutate({ bulkAcceptDisabled: e.target.checked })}
+                onChange={(e) => {
+                  const checked = e.target.checked;
+                  updateSettings.mutate(
+                    { bulkAcceptDisabled: checked },
+                    {
+                      onSuccess: () => setLastResult(checked ? 'Bulk-accept disabled for this tenant' : 'Bulk-accept re-enabled'),
+                      onError: (err: any) => setLastResult(`Failed to update setting: ${err.message}`),
+                    },
+                  );
+                }}
+                disabled={updateSettings.isPending}
                 className="rounded border-[hsl(var(--cf-border))]"
               />
               Disable bulk-accept for this tenant
@@ -366,7 +390,7 @@ interface ReconciledRowProps {
 
 function ReconciledRow({ tx, coaMap, onUnreconcile, isUnreconciling }: ReconciledRowProps) {
   const [showAudit, setShowAudit] = useState(false);
-  const { data: auditLog } = useClassificationAudit(showAudit ? tx.id : null);
+  const { data: auditLog, isLoading: auditLoading } = useClassificationAudit(showAudit ? tx.id : null);
   const account = tx.coaCode ? coaMap.get(tx.coaCode) : null;
   const amount = parseFloat(tx.amount);
 
@@ -414,35 +438,34 @@ function ReconciledRow({ tx, coaMap, onUnreconcile, isUnreconciling }: Reconcile
       </div>
 
       {/* Audit trail expansion */}
-      {showAudit && auditLog && auditLog.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-[hsl(var(--cf-border))] space-y-1">
-          {auditLog.map((entry) => (
-            <div key={entry.id} className="flex items-baseline gap-2 text-[10px]">
-              <span className="text-[hsl(var(--cf-text-muted))] w-[70px] shrink-0">{formatDate(entry.createdAt)}</span>
-              <span className={`w-[60px] shrink-0 ${
-                entry.action === 'reconcile' ? 'text-yellow-400' :
-                entry.action.includes('classify') ? 'text-green-400' :
-                'text-[hsl(var(--cf-text-muted))]'
-              }`}>{entry.action}</span>
-              <span className="text-[hsl(var(--cf-text))]">{entry.newCoaCode}</span>
-              {entry.previousCoaCode && (
-                <span className="text-[hsl(var(--cf-text-muted))]">(was {entry.previousCoaCode})</span>
-              )}
-              <span className="text-[hsl(var(--cf-text-muted))]">
-                {entry.trustLevel} by {entry.actorId}
-              </span>
-              {entry.confidence && (
-                <span className={confidenceColor(parseFloat(entry.confidence))}>
-                  {(parseFloat(entry.confidence) * 100).toFixed(0)}%
-                </span>
-              )}
+      {showAudit && (
+        <div className="mt-3 pt-3 border-t border-[hsl(var(--cf-border))]">
+          {auditLoading ? (
+            <div className="text-[10px] text-[hsl(var(--cf-text-muted))]">Loading audit trail...</div>
+          ) : auditLog && auditLog.length > 0 ? (
+            <div className="space-y-1">
+              {auditLog.map((entry) => (
+                <div key={entry.id} className="flex items-baseline gap-2 text-[10px]">
+                  <span className="text-[hsl(var(--cf-text-muted))] w-[70px] shrink-0">{formatDate(entry.createdAt)}</span>
+                  <span className={`w-[60px] shrink-0 ${auditActionColor(entry.action)}`}>{entry.action}</span>
+                  <span className="text-[hsl(var(--cf-text))]">{entry.newCoaCode}</span>
+                  {entry.previousCoaCode && (
+                    <span className="text-[hsl(var(--cf-text-muted))]">(was {entry.previousCoaCode})</span>
+                  )}
+                  <span className="text-[hsl(var(--cf-text-muted))]">
+                    {entry.trustLevel} by {entry.actorId}
+                  </span>
+                  {entry.confidence && (
+                    <span className={confidenceColor(parseFloat(entry.confidence))}>
+                      {(parseFloat(entry.confidence) * 100).toFixed(0)}%
+                    </span>
+                  )}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
-      {showAudit && (!auditLog || auditLog.length === 0) && (
-        <div className="mt-3 pt-3 border-t border-[hsl(var(--cf-border))] text-[10px] text-[hsl(var(--cf-text-muted))]">
-          No audit entries found
+          ) : (
+            <div className="text-[10px] text-[hsl(var(--cf-text-muted))]">No audit entries found</div>
+          )}
         </div>
       )}
     </div>

--- a/server/routes/tenants.ts
+++ b/server/routes/tenants.ts
@@ -42,63 +42,70 @@ tenantRoutes.get('/api/tenants/:id', async (c) => {
   });
 });
 
-// PATCH /api/tenants/:id/settings — update tenant metadata settings (owner/admin only)
+// ── Settings helpers ──
+
 const settingsSchema = z.object({
   bulkAcceptDisabled: z.boolean().optional(),
-}).passthrough(); // allow arbitrary metadata keys
+}).strict();
 
-tenantRoutes.patch('/api/tenants/:id/settings', async (c) => {
+/** Verify user membership and fetch tenant, returning both or a 404 response. */
+async function resolveUserTenant(c: any) {
   const storage = c.get('storage');
   const userId = c.get('userId');
   const tenantId = c.req.param('id');
 
-  // Verify access and role
   const memberships = await storage.getUserTenants(userId);
-  const membership = memberships.find((item) => item.tenant.id === tenantId);
-  if (!membership) return c.json({ error: 'Tenant not found' }, 404);
+  const membership = memberships.find((item: any) => item.tenant.id === tenantId);
+  if (!membership) return { error: c.json({ error: 'Tenant not found' }, 404) } as const;
 
-  if (!['owner', 'admin'].includes(membership.role)) {
+  const tenant = await storage.getTenant(tenantId);
+  if (!tenant) return { error: c.json({ error: 'Tenant not found' }, 404) } as const;
+
+  return { membership, tenant, tenantId, userId, storage } as const;
+}
+
+// GET /api/tenants/:id/settings — get tenant settings (classification flags, etc.)
+tenantRoutes.get('/api/tenants/:id/settings', async (c) => {
+  const result = await resolveUserTenant(c);
+  if ('error' in result) return result.error;
+
+  const metadata = (result.tenant.metadata as Record<string, unknown>) ?? {};
+  return c.json({
+    bulkAcceptDisabled: metadata.bulkAcceptDisabled ?? false,
+  });
+});
+
+// PATCH /api/tenants/:id/settings — update tenant metadata settings (owner/admin only)
+tenantRoutes.patch('/api/tenants/:id/settings', async (c) => {
+  const result = await resolveUserTenant(c);
+  if ('error' in result) return result.error;
+
+  if (!['owner', 'admin'].includes(result.membership.role)) {
     return c.json({ error: 'Owner or admin role required to modify tenant settings' }, 403);
   }
 
-  const body = settingsSchema.safeParse(await c.req.json().catch(() => ({})));
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
+    return c.json({ error: 'Request body must be valid JSON' }, 400);
+  }
+  const body = settingsSchema.safeParse(rawBody);
   if (!body.success) {
     return c.json({ error: 'invalid_body', details: body.error.flatten() }, 400);
   }
 
-  const tenant = await storage.getTenant(tenantId);
-  if (!tenant) return c.json({ error: 'Tenant not found' }, 404);
-
-  const currentMetadata = (tenant.metadata as Record<string, unknown>) ?? {};
+  const currentMetadata = (result.tenant.metadata as Record<string, unknown>) ?? {};
   const updatedMetadata = { ...currentMetadata, ...body.data };
 
-  const updated = await storage.updateTenant(tenantId, { metadata: updatedMetadata });
+  const updated = await result.storage.updateTenant(result.tenantId, { metadata: updatedMetadata });
   if (!updated) return c.json({ error: 'Update failed' }, 500);
 
   ledgerLog(c, {
     entityType: 'audit',
     action: 'tenant.settings_updated',
-    metadata: { tenantId, changes: Object.keys(body.data), actorId: userId },
+    metadata: { tenantId: result.tenantId, changes: Object.keys(body.data), actorId: result.userId },
   }, c.env);
 
   return c.json(updated);
-});
-
-// GET /api/tenants/:id/settings — get tenant settings (classification flags, etc.)
-tenantRoutes.get('/api/tenants/:id/settings', async (c) => {
-  const storage = c.get('storage');
-  const userId = c.get('userId');
-  const tenantId = c.req.param('id');
-
-  const memberships = await storage.getUserTenants(userId);
-  const membership = memberships.find((item) => item.tenant.id === tenantId);
-  if (!membership) return c.json({ error: 'Tenant not found' }, 404);
-
-  const tenant = await storage.getTenant(tenantId);
-  if (!tenant) return c.json({ error: 'Tenant not found' }, 404);
-
-  const metadata = (tenant.metadata as Record<string, unknown>) ?? {};
-  return c.json({
-    bulkAcceptDisabled: metadata.bulkAcceptDisabled ?? false,
-  });
 });

--- a/server/routes/tenants.ts
+++ b/server/routes/tenants.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { HonoEnv } from '../env';
+import { ledgerLog } from '../lib/ledger-client';
 
 export const tenantRoutes = new Hono<HonoEnv>();
 
@@ -37,5 +39,66 @@ tenantRoutes.get('/api/tenants/:id', async (c) => {
   return c.json({
     ...tenant,
     role: membership.role,
+  });
+});
+
+// PATCH /api/tenants/:id/settings — update tenant metadata settings (owner/admin only)
+const settingsSchema = z.object({
+  bulkAcceptDisabled: z.boolean().optional(),
+}).passthrough(); // allow arbitrary metadata keys
+
+tenantRoutes.patch('/api/tenants/:id/settings', async (c) => {
+  const storage = c.get('storage');
+  const userId = c.get('userId');
+  const tenantId = c.req.param('id');
+
+  // Verify access and role
+  const memberships = await storage.getUserTenants(userId);
+  const membership = memberships.find((item) => item.tenant.id === tenantId);
+  if (!membership) return c.json({ error: 'Tenant not found' }, 404);
+
+  if (!['owner', 'admin'].includes(membership.role)) {
+    return c.json({ error: 'Owner or admin role required to modify tenant settings' }, 403);
+  }
+
+  const body = settingsSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!body.success) {
+    return c.json({ error: 'invalid_body', details: body.error.flatten() }, 400);
+  }
+
+  const tenant = await storage.getTenant(tenantId);
+  if (!tenant) return c.json({ error: 'Tenant not found' }, 404);
+
+  const currentMetadata = (tenant.metadata as Record<string, unknown>) ?? {};
+  const updatedMetadata = { ...currentMetadata, ...body.data };
+
+  const updated = await storage.updateTenant(tenantId, { metadata: updatedMetadata });
+  if (!updated) return c.json({ error: 'Update failed' }, 500);
+
+  ledgerLog(c, {
+    entityType: 'audit',
+    action: 'tenant.settings_updated',
+    metadata: { tenantId, changes: Object.keys(body.data), actorId: userId },
+  }, c.env);
+
+  return c.json(updated);
+});
+
+// GET /api/tenants/:id/settings — get tenant settings (classification flags, etc.)
+tenantRoutes.get('/api/tenants/:id/settings', async (c) => {
+  const storage = c.get('storage');
+  const userId = c.get('userId');
+  const tenantId = c.req.param('id');
+
+  const memberships = await storage.getUserTenants(userId);
+  const membership = memberships.find((item) => item.tenant.id === tenantId);
+  if (!membership) return c.json({ error: 'Tenant not found' }, 404);
+
+  const tenant = await storage.getTenant(tenantId);
+  if (!tenant) return c.json({ error: 'Tenant not found' }, 404);
+
+  const metadata = (tenant.metadata as Record<string, unknown>) ?? {};
+  return c.json({
+    bulkAcceptDisabled: metadata.bulkAcceptDisabled ?? false,
   });
 });

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -180,10 +180,10 @@ export class SystemStorage {
     return row;
   }
 
-  async updateTenant(id: string, data: { metadata?: unknown }) {
+  async updateTenant(id: string, data: { metadata: Record<string, unknown> }) {
     const [row] = await this.db
       .update(schema.tenants)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ metadata: data.metadata, updatedAt: new Date() })
       .where(eq(schema.tenants.id, id))
       .returning();
     return row;

--- a/server/storage/system.ts
+++ b/server/storage/system.ts
@@ -180,6 +180,15 @@ export class SystemStorage {
     return row;
   }
 
+  async updateTenant(id: string, data: { metadata?: unknown }) {
+    const [row] = await this.db
+      .update(schema.tenants)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(schema.tenants.id, id))
+      .returning();
+    return row;
+  }
+
   async getTenantBySlug(slug: string) {
     const [row] = await this.db.select().from(schema.tenants).where(eq(schema.tenants.slug, slug));
     return row;


### PR DESCRIPTION
## Summary
- **Reconciled-row L3 audit visibility** — reconciled tab now shows classifiedBy/classifiedAt, plus expandable per-transaction audit trail showing full trust-path history (suggest → classify → reconcile)
- **Bulk-accept opt-out** — per-tenant `bulkAcceptDisabled` flag in tenant metadata. UI hides "Accept High-Confidence" when enabled. Toggle in Reconciled tab for owner/admin.
- **Tenant settings API** — `GET/PATCH /api/tenants/:id/settings` for classification governance flags
- **`updateTenant()`** added to SystemStorage for metadata writes
- Wave webhook classification already shipped in PR #90 (verified)
- 4010.CO sub-account can be created via existing L4 COA API

## Test plan
- [x] TypeScript clean (`tsc --noEmit`)
- [x] 253/253 tests pass
- [x] No breaking changes to existing classification flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)