### PR TITLE
chore(governance): add governance gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @chitcommit

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,36 @@
+# ChittyOS PR Governance - Caller Workflow
+#
+# Copy this file to your repository at: .github/workflows/governance.yml
+#
+# IMPORTANT: Replace <SHA> with the current commit SHA of chittycanon.
+# This ensures the governance workflow cannot be modified without your knowledge.
+#
+# To get the current SHA:
+#   git ls-remote https://github.com/CHITTYFOUNDATION/chittycanon refs/heads/main
+#
+# Or run the deploy script which will update this automatically.
+
+name: Governance
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - production
+      - 'release/**'
+
+jobs:
+  governance:
+    name: PR Governance Check
+    # Pin to exact SHA - NEVER use branch or tag reference
+    # This ensures governance rules cannot be modified without updating all repos
+    uses: CHITTYFOUNDATION/chittycanon/.github/workflows/pr-governance.yml@83a7d1da1cfa5041f18450a6d43ff336068285de
+    with:
+      governance_version: main
+
+  hardening:
+    name: Portfolio Hardening Check
+    uses: CHITTYFOUNDATION/chittycanon/.github/workflows/portfolio-hardening.yml@83a7d1da1cfa5041f18450a6d43ff336068285de
+    with:
+      tier: "2"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -110,19 +110,17 @@ jobs:
           # If rules are unsigned, fall back to a minimal bootstrap set.
           SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
           if [[ -z "$SIGNATURE" ]]; then
-            PROTECTED_PATTERNS=$(cat <<'EOF'
-.github/workflows/**
-.github/CODEOWNERS
-CODEOWNERS
-governance/**
-EOF
-            )
+            mapfile -t PROTECTED_PATTERNS < <(printf '%s\n' \
+              ".github/workflows/**" \
+              ".github/CODEOWNERS" \
+              "CODEOWNERS" \
+              "governance/**")
           else
-            PROTECTED_PATTERNS=$(jq -r '.rules.protected_files.files[]' rules.json)
+            mapfile -t PROTECTED_PATTERNS < <(jq -r '.rules.protected_files.files[]' rules.json)
           fi
           VIOLATIONS=""
 
-          for pattern in $PROTECTED_PATTERNS; do
+          for pattern in "${PROTECTED_PATTERNS[@]}"; do
             REGEX=$(echo "$pattern" | sed 's/\*\*/.*/' | sed 's/\*/.*/g')
             while IFS= read -r file; do
               if [[ "$file" =~ $REGEX ]]; then

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -52,7 +52,7 @@ jobs:
               ) + "$";
             .repos
             | map(. + { re: (glob_to_re(.repo)) })
-            | map(select($repo | test(.re)))
+            | map(select(.re as $re | $repo | test($re)))
             | .[0].tier // 99
           ' repo_requirements.json 2>/dev/null || echo "99")
           echo "tier=$tier" >> "$GITHUB_OUTPUT"
@@ -181,7 +181,7 @@ jobs:
               ) + "$";
             .repos
             | map(. + { re: (glob_to_re(.repo)) })
-            | map(select($repo | test(.re)))
+            | map(select(.re as $re | $repo | test($re)))
             | .[0] // empty
           ' repo_requirements.json)
 

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,14 +1,10 @@
-# ChittyOS PR Governance - Caller Workflow
+# Governance (Monolithic)
 #
-# Copy this file to your repository at: .github/workflows/governance.yml
+# Deployed into each repository as: .github/workflows/governance.yml
 #
-# IMPORTANT: Replace <SHA> with the current commit SHA of chittycanon.
-# This ensures the governance workflow cannot be modified without your knowledge.
+# Rationale: self-contained workflow avoids cross-org reusable workflow restrictions
+# and allows the governance gate to run on the bootstrap PR itself.
 #
-# To get the current SHA:
-#   git ls-remote https://github.com/CHITTYFOUNDATION/chittycanon refs/heads/main
-#
-# Or run the deploy script which will update this automatically.
 
 name: Governance
 
@@ -20,17 +16,208 @@ on:
       - production
       - 'release/**'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   governance:
     name: PR Governance Check
-    # Pin to exact SHA - NEVER use branch or tag reference
-    # This ensures governance rules cannot be modified without updating all repos
-    uses: CHITTYFOUNDATION/chittycanon/.github/workflows/pr-governance.yml@83a7d1da1cfa5041f18450a6d43ff336068285de
-    with:
-      governance_version: main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch Governance Rules
+        run: |
+          # Public distribution repo (rules are signed; safe to publish)
+          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/rules.json" -o rules.json
+          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/CANON_PUBLIC_KEY" -o CANON_PUBLIC_KEY
+
+      - name: Verify Rules Signature
+        run: |
+          SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
+          if [[ -z "$SIGNATURE" ]]; then
+            echo "::error::Governance rules are NOT SIGNED. Human must run sign-rules.sh and publish CANON_PUBLIC_KEY + signed rules.json."
+            exit 1
+          fi
+
+          CANONICAL=$(jq -cS 'del(.signature.signature) | del(.signature.signed_at)' rules.json)
+          echo -n "$CANONICAL" > canonical.json
+          echo "$SIGNATURE" | base64 -d > signature.bin
+
+          openssl pkeyutl -verify -pubin -inkey CANON_PUBLIC_KEY -sigfile signature.bin -in canonical.json
+
+      - name: Require CODEOWNERS
+        run: |
+          if [[ -f "CODEOWNERS" || -f ".github/CODEOWNERS" || -f "docs/CODEOWNERS" ]]; then
+            exit 0
+          fi
+          echo "::error::Missing CODEOWNERS"
+          exit 1
+
+      - name: Check Protected File Changes
+        run: |
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          PROTECTED_PATTERNS=$(jq -r '.rules.protected_files.files[]' rules.json)
+          VIOLATIONS=""
+
+          for pattern in $PROTECTED_PATTERNS; do
+            REGEX=$(echo "$pattern" | sed 's/\*\*/.*/' | sed 's/\*/.*/g')
+            while IFS= read -r file; do
+              if [[ "$file" =~ $REGEX ]]; then
+                VIOLATIONS="${VIOLATIONS}${file} matches protected pattern: ${pattern}\n"
+              fi
+            done <<< "$CHANGED_FILES"
+          done
+
+          if [[ -n "$VIOLATIONS" ]]; then
+            echo "::warning::Protected files modified (extra scrutiny required):"
+            echo -e "$VIOLATIONS"
+          fi
+
+      - name: Require Human Approval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const humanApprovals = reviews.filter(r => r.state === 'APPROVED' && !r.user.login.includes('[bot]'));
+            const required = 1;
+            if (humanApprovals.length < required) {
+              core.setFailed(`Requires at least ${required} human approval(s). Current: ${humanApprovals.length}`);
+            }
 
   hardening:
     name: Portfolio Hardening Check
-    uses: CHITTYFOUNDATION/chittycanon/.github/workflows/portfolio-hardening.yml@83a7d1da1cfa5041f18450a6d43ff336068285de
-    with:
-      tier: "2"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Baseline Hardening
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail() { echo "::error::$1"; exit 1; }
+          warn() { echo "::warning::$1"; }
+
+          OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/owners.json"
+          REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/repo_requirements.json"
+          curl -sL "$OWNERS_URL" -o owners.json || fail "Unable to fetch ownership registry: $OWNERS_URL"
+          curl -sL "$REQS_URL" -o repo_requirements.json || fail "Unable to fetch repo requirements: $REQS_URL"
+
+          if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
+            fail "Missing SECURITY.md"
+          fi
+          if git ls-files --error-unmatch .env >/dev/null 2>&1; then
+            fail "Tracked .env detected"
+          fi
+          if git ls-files | grep -qE '(^|/)node_modules/'; then
+            fail "Tracked node_modules detected"
+          fi
+          if git ls-files | grep -qE '(^|/)\\.wrangler/'; then
+            fail "Tracked .wrangler detected"
+          fi
+          if [[ -f "package.json" ]]; then
+            LOCKS=0
+            [[ -f "package-lock.json" ]] && LOCKS=$((LOCKS+1))
+            [[ -f "pnpm-lock.yaml" ]] && LOCKS=$((LOCKS+1))
+            [[ -f "yarn.lock" ]] && LOCKS=$((LOCKS+1))
+            if [[ "$LOCKS" -eq 0 ]]; then
+              fail "package.json present but no lockfile found"
+            fi
+          fi
+
+          # Eligibility gating (warn-only until registry is populated)
+          OWNERS_FILE="CODEOWNERS"
+          [[ -f ".github/CODEOWNERS" ]] && OWNERS_FILE=".github/CODEOWNERS"
+          PRINCIPALS=$(sed 's/#.*$//' "$OWNERS_FILE" | tr '\t' ' ' | tr ' ' '\n' | grep '^@' | sort -u || true)
+          [[ -n "$PRINCIPALS" ]] || exit 0
+
+          FULL_REPO="${GITHUB_REPOSITORY}"
+          REQUIREMENT=$(jq -c --arg repo "$FULL_REPO" '
+            def glob_to_re($g):
+              "^" + ($g
+                | gsub("\\."; "\\\\.")
+                | gsub("\\*\\*"; ".*")
+                | gsub("\\*"; "[^/]*")
+              ) + "$";
+            .repos
+            | map(. + { re: (glob_to_re(.repo)) })
+            | map(select($repo | test(.re)))
+            | .[0] // empty
+          ' repo_requirements.json)
+
+          [[ -n "$REQUIREMENT" ]] || exit 0
+
+          REQ_TY=$(echo "$REQUIREMENT" | jq -r '.requires.ty[]?' 2>/dev/null || true)
+          REQ_VY=$(echo "$REQUIREMENT" | jq -r '.requires.vy[]?' 2>/dev/null || true)
+          REQ_RY=$(echo "$REQUIREMENT" | jq -r '.requires.ry[]?' 2>/dev/null || true)
+
+          now_epoch=$(date -u +%s)
+          term_present() {
+            local row_json="$1"; local dim="$2"; local term="$3"
+            echo "$row_json" | jq -e --arg dim "$dim" --arg term "$term" '
+              ((.[ $dim ].given // []) | any(.term == $term)) or
+              ((.[ $dim ].earned // []) | any(.term == $term))
+            ' >/dev/null
+          }
+          term_is_given() {
+            local row_json="$1"; local dim="$2"; local term="$3"
+            echo "$row_json" | jq -e --arg dim "$dim" --arg term "$term" '
+              ((.[ $dim ].given // []) | any(.term == $term))
+            ' >/dev/null
+          }
+          given_expiry_ok() {
+            local row_json="$1"; local dim="$2"; local term="$3"; local exp; local exp_epoch
+            exp=$(echo "$row_json" | jq -r --arg dim "$dim" --arg term "$term" '
+              ([.[ $dim ].given[]? | select(.term == $term) | .expires_at] | .[0]) // empty
+            ')
+            [[ -n "$exp" ]] || return 2
+            exp_epoch=$(date -u -d "$exp" +%s 2>/dev/null || echo "")
+            [[ -n "$exp_epoch" ]] || return 3
+            [[ "$exp_epoch" -ge "$now_epoch" ]]
+          }
+
+          while IFS= read -r principal; do
+            [[ -z "$principal" ]] && continue
+            row=$(jq -c --arg gh "$principal" '.principals[]? | select(.github==$gh)' owners.json || true)
+            if [[ -z "$row" ]]; then
+              warn "CODEOWNERS principal missing from registry: $principal"
+              continue
+            fi
+            ok="true"
+            for t in $REQ_TY; do
+              term_present "$row" "ty" "$t" || ok="false"
+              if term_is_given "$row" "ty" "$t"; then
+                if ! given_expiry_ok "$row" "ty" "$t"; then ok="false"; fi
+              fi
+            done
+            for v in $REQ_VY; do
+              term_present "$row" "vy" "$v" || ok="false"
+              if term_is_given "$row" "vy" "$v"; then
+                if ! given_expiry_ok "$row" "vy" "$v"; then ok="false"; fi
+              fi
+            done
+            for r in $REQ_RY; do
+              term_present "$row" "ry" "$r" || ok="false"
+              if term_is_given "$row" "ry" "$r"; then
+                if ! given_expiry_ok "$row" "ry" "$r"; then ok="false"; fi
+              fi
+            done
+            if [[ "$ok" != "true" ]]; then
+              warn "CODEOWNERS principal fails TY/VY/RY eligibility: $principal"
+            fi
+          done <<< "$PRINCIPALS"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -95,7 +95,22 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            const humanApprovals = reviews.filter(r => r.state === 'APPROVED' && !r.user.login.includes('[bot]'));
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              if (!review.user || review.user.login.includes('[bot]')) {
+                continue;
+              }
+              const existing = latestReviewByUser.get(review.user.login);
+              if (
+                !existing ||
+                new Date(review.submitted_at).getTime() > new Date(existing.submitted_at).getTime()
+              ) {
+                latestReviewByUser.set(review.user.login, review);
+              }
+            }
+            const humanApprovals = Array.from(latestReviewByUser.values()).filter(
+              review => review.state === 'APPROVED'
+            );
             const required = 1;
             if (humanApprovals.length < required) {
               core.setFailed(`Requires at least ${required} human approval(s). Current: ${humanApprovals.length}`);

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -96,11 +96,19 @@ jobs:
             CHANGED_FILES="$CHANGED_FILES" python3 - <<'PY'
 import json
 import os
+import sys
 from pathlib import PurePosixPath
 
 changed_files = [line for line in os.environ.get("CHANGED_FILES", "").splitlines() if line]
-with open("rules.json", "r", encoding="utf-8") as f:
-    rules = json.load(f)
+try:
+    with open("rules.json", "r", encoding="utf-8") as f:
+        rules = json.load(f)
+except FileNotFoundError:
+    print("Missing rules.json", file=sys.stderr)
+    sys.exit(2)
+except json.JSONDecodeError as exc:
+    print(f"Invalid rules.json: {exc}", file=sys.stderr)
+    sys.exit(2)
 
 protected_patterns = rules.get("rules", {}).get("protected_files", {}).get("files", [])
 violations = []
@@ -189,8 +197,9 @@ PY
           if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
             fail "Missing SECURITY.md"
           fi
-          if git ls-files | grep -qE '(^|/)\.env(\..+)?$'; then
-            fail "Tracked .env file detected"
+          DOTENV_FILES=$(git ls-files | grep -E '(^|/)\.env(\..+)?$' || true)
+          if [[ -n "$DOTENV_FILES" ]]; then
+            fail "Tracked .env file(s) detected: ${DOTENV_FILES//$'\n'/, }"
           fi
           if git ls-files | grep -qE '(^|/)node_modules/'; then
             fail "Tracked node_modules detected"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -56,34 +56,23 @@ jobs:
 
       - name: Verify Rules Signature
         run: |
-          fetch_file() {
-            local url="$1"
-            local output="$2"
-            local label="$3"
-            curl --fail --show-error --silent --location \
-              --retry 5 \
-              --retry-delay 2 \
-              --retry-max-time 30 \
-              --retry-all-errors \
-              "$url" -o "$output" || {
-                echo "::error::Unable to fetch ${label}: $url"
-                exit 1
-              }
-          }
-
           SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
           if [[ -z "$SIGNATURE" ]]; then
             echo "::error::Governance rules are NOT SIGNED. Human must run sign-rules.sh and publish CANON_PUBLIC_KEY + signed rules.json."
             exit 1
           fi
 
-          fetch_file "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/CANON_PUBLIC_KEY" "CANON_PUBLIC_KEY" "governance public key"
+          CANON_KEY_FILE="governance/CANON_PUBLIC_KEY"
+          if [[ ! -f "$CANON_KEY_FILE" ]]; then
+            echo "::error::Missing trusted governance public key at ${CANON_KEY_FILE}"
+            exit 1
+          fi
 
           CANONICAL=$(jq -cS 'del(.signature.signature) | del(.signature.signed_at)' rules.json)
           echo -n "$CANONICAL" > canonical.json
           echo "$SIGNATURE" | base64 -d > signature.bin
 
-          openssl pkeyutl -verify -pubin -inkey CANON_PUBLIC_KEY -sigfile signature.bin -in canonical.json
+          openssl pkeyutl -verify -pubin -inkey "$CANON_KEY_FILE" -sigfile signature.bin -in canonical.json
 
       - name: Require CODEOWNERS
         run: |
@@ -103,41 +92,42 @@ jobs:
           echo "$CHANGED_FILES"
           echo ""
 
-          PROTECTED_PATTERNS=$(jq -r '.rules.protected_files.files[]' rules.json)
-          VIOLATIONS=""
-
-          while IFS= read -r pattern; do
-            [[ -z "$pattern" ]] && continue
-            while IFS= read -r file; do
-              [[ -z "$file" ]] && continue
-              if python3 - "$pattern" "$file" <<'PY'
-import sys
+          VIOLATIONS=$(
+            CHANGED_FILES="$CHANGED_FILES" python3 - <<'PY'
+import json
+import os
 from pathlib import PurePosixPath
 
-pattern = sys.argv[1]
-file_path = sys.argv[2]
+changed_files = [line for line in os.environ.get("CHANGED_FILES", "").splitlines() if line]
+with open("rules.json", "r", encoding="utf-8") as f:
+    rules = json.load(f)
 
-sys.exit(0 if PurePosixPath(file_path).match(pattern) else 1)
+protected_patterns = rules.get("rules", {}).get("protected_files", {}).get("files", [])
+violations = []
+
+for pattern in protected_patterns:
+    for file in changed_files:
+        if PurePosixPath(file).match(pattern):
+            violations.append(f"{file} matches protected pattern: {pattern}")
+
+print("\n".join(violations))
 PY
-              then
-                VIOLATIONS="${VIOLATIONS}${file} matches protected pattern: ${pattern}\n"
-              fi
-            done <<< "$CHANGED_FILES"
-          done <<< "$PROTECTED_PATTERNS"
+          )
 
           if [[ -n "$VIOLATIONS" ]]; then
             echo "::warning::Protected files modified (extra scrutiny required):"
-            echo -e "$VIOLATIONS"
+            echo "$VIOLATIONS"
           fi
 
       - name: Require Human Approval
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: reviews } = await github.rest.pulls.listReviews({
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
             });
             const latestReviewByUser = new Map();
             for (const review of reviews) {
@@ -193,12 +183,14 @@ PY
           REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/repo_requirements.json"
           fetch_json "$OWNERS_URL" owners.json "ownership registry"
           fetch_json "$REQS_URL" repo_requirements.json "repo requirements"
+          jq -e 'type == "object"' owners.json >/dev/null || fail "Invalid ownership registry JSON"
+          jq -e 'type == "object"' repo_requirements.json >/dev/null || fail "Invalid repo requirements JSON"
 
           if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
             fail "Missing SECURITY.md"
           fi
-          if git ls-files --error-unmatch .env >/dev/null 2>&1; then
-            fail "Tracked .env detected"
+          if git ls-files | grep -qE '(^|/)\.env(\..+)?$'; then
+            fail "Tracked .env file detected"
           fi
           if git ls-files | grep -qE '(^|/)node_modules/'; then
             fail "Tracked node_modules detected"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -17,7 +17,7 @@ on:
       - 'release/**'
 
 env:
-  GOVERNANCE_REF: 8cd6fe0f29268b256368bdfc9b37d4745cc3f380
+  GOVERNANCE_REF: 83a7d1da1cfa5041f18450a6d43ff336068285de
 
 permissions: {}
 
@@ -131,6 +131,8 @@ PY
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
+            const path = require('path');
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -156,6 +158,38 @@ PY
             const required = 1;
             if (humanApprovals.length < required) {
               core.setFailed(`Requires at least ${required} human approval(s). Current: ${humanApprovals.length}`);
+              return;
+            }
+
+            const workspace = process.env.GITHUB_WORKSPACE || '.';
+            const ownerFile = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
+              .find(file => fs.existsSync(path.join(workspace, file)));
+            if (!ownerFile) {
+              core.setFailed('Missing CODEOWNERS');
+              return;
+            }
+
+            const ownerContent = fs.readFileSync(path.join(workspace, ownerFile), 'utf8');
+            const individualOwners = new Set();
+            for (const rawLine of ownerContent.split('\n')) {
+              const line = rawLine.replace(/#.*/, '').trim();
+              if (!line) continue;
+              for (const token of line.split(/\s+/).slice(1)) {
+                if (!token.startsWith('@') || token.includes('/')) continue;
+                individualOwners.add(token.slice(1).toLowerCase());
+              }
+            }
+
+            if (individualOwners.size === 0) {
+              core.setFailed(`No individual CODEOWNERS entries found in ${ownerFile}; add at least one @username owner for enforcement.`);
+              return;
+            }
+
+            const codeOwnerApprovals = humanApprovals.filter(review =>
+              individualOwners.has(review.user.login.toLowerCase())
+            );
+            if (codeOwnerApprovals.length < 1) {
+              core.setFailed('Requires at least 1 approval from an individual CODEOWNER listed in CODEOWNERS.');
             }
 
   hardening:

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -115,11 +115,22 @@ jobs:
           set -euo pipefail
           fail() { echo "::error::$1"; exit 1; }
           warn() { echo "::warning::$1"; }
+          fetch_json() {
+            local url="$1"
+            local output="$2"
+            local label="$3"
+            curl --fail --show-error --silent --location \
+              --retry 5 \
+              --retry-delay 2 \
+              --retry-max-time 30 \
+              --retry-all-errors \
+              "$url" -o "$output" || fail "Unable to fetch ${label}: $url"
+          }
 
           OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/owners.json"
           REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/repo_requirements.json"
-          curl -sL "$OWNERS_URL" -o owners.json || fail "Unable to fetch ownership registry: $OWNERS_URL"
-          curl -sL "$REQS_URL" -o repo_requirements.json || fail "Unable to fetch repo requirements: $REQS_URL"
+          fetch_json "$OWNERS_URL" owners.json "ownership registry"
+          fetch_json "$REQS_URL" repo_requirements.json "repo requirements"
 
           if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
             fail "Missing SECURITY.md"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -73,9 +73,17 @@ jobs:
           VIOLATIONS=""
 
           for pattern in $PROTECTED_PATTERNS; do
-            REGEX=$(echo "$pattern" | sed 's/\*\*/.*/' | sed 's/\*/.*/g')
             while IFS= read -r file; do
-              if [[ "$file" =~ $REGEX ]]; then
+              if python3 - "$pattern" "$file" <<'PY'
+import sys
+from pathlib import PurePosixPath
+
+pattern = sys.argv[1]
+file_path = sys.argv[2]
+
+sys.exit(0 if PurePosixPath(file_path).match(pattern) else 1)
+PY
+              then
                 VIOLATIONS="${VIOLATIONS}${file} matches protected pattern: ${pattern}\n"
               fi
             done <<< "$CHANGED_FILES"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -16,14 +16,15 @@ on:
       - production
       - 'release/**'
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   governance:
     name: PR Governance Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -100,6 +101,8 @@ jobs:
   hardening:
     name: Portfolio Hardening Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -16,6 +16,9 @@ on:
       - production
       - 'release/**'
 
+env:
+  GOVERNANCE_REF: 8cd6fe0f29268b256368bdfc9b37d4745cc3f380
+
 permissions: {}
 
 jobs:
@@ -33,20 +36,48 @@ jobs:
 
       - name: Fetch Governance Rules
         run: |
-          # Public distribution repo (rules are signed; safe to publish)
-          # Pin to an immutable upstream revision so rules.json and CANON_PUBLIC_KEY
-          # cannot both be replaced via changes to a moving branch ref.
-          GOVERNANCE_REF="0123456789abcdef0123456789abcdef01234567"
-          curl -fsSL "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/rules.json" -o rules.json
-          curl -fsSL "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/CANON_PUBLIC_KEY" -o CANON_PUBLIC_KEY
+          fetch_file() {
+            local url="$1"
+            local output="$2"
+            local label="$3"
+            curl --fail --show-error --silent --location \
+              --retry 5 \
+              --retry-delay 2 \
+              --retry-max-time 30 \
+              --retry-all-errors \
+              "$url" -o "$output" || {
+                echo "::error::Unable to fetch ${label}: $url"
+                exit 1
+              }
+          }
+
+          # Pin governance artifacts to immutable revision for stable trust root.
+          fetch_file "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/rules.json" "rules.json" "governance rules"
 
       - name: Verify Rules Signature
         run: |
+          fetch_file() {
+            local url="$1"
+            local output="$2"
+            local label="$3"
+            curl --fail --show-error --silent --location \
+              --retry 5 \
+              --retry-delay 2 \
+              --retry-max-time 30 \
+              --retry-all-errors \
+              "$url" -o "$output" || {
+                echo "::error::Unable to fetch ${label}: $url"
+                exit 1
+              }
+          }
+
           SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
           if [[ -z "$SIGNATURE" ]]; then
             echo "::error::Governance rules are NOT SIGNED. Human must run sign-rules.sh and publish CANON_PUBLIC_KEY + signed rules.json."
             exit 1
           fi
+
+          fetch_file "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/CANON_PUBLIC_KEY" "CANON_PUBLIC_KEY" "governance public key"
 
           CANONICAL=$(jq -cS 'del(.signature.signature) | del(.signature.signed_at)' rules.json)
           echo -n "$CANONICAL" > canonical.json
@@ -72,8 +103,10 @@ jobs:
           PROTECTED_PATTERNS=$(jq -r '.rules.protected_files.files[]' rules.json)
           VIOLATIONS=""
 
-          for pattern in $PROTECTED_PATTERNS; do
+          while IFS= read -r pattern; do
+            [[ -z "$pattern" ]] && continue
             while IFS= read -r file; do
+              [[ -z "$file" ]] && continue
               if python3 - "$pattern" "$file" <<'PY'
 import sys
 from pathlib import PurePosixPath
@@ -87,7 +120,7 @@ PY
                 VIOLATIONS="${VIOLATIONS}${file} matches protected pattern: ${pattern}\n"
               fi
             done <<< "$CHANGED_FILES"
-          done
+          done <<< "$PROTECTED_PATTERNS"
 
           if [[ -n "$VIOLATIONS" ]]; then
             echo "::warning::Protected files modified (extra scrutiny required):"
@@ -153,8 +186,8 @@ PY
               "$url" -o "$output" || fail "Unable to fetch ${label}: $url"
           }
 
-          OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/owners.json"
-          REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/repo_requirements.json"
+          OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/owners.json"
+          REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/repo_requirements.json"
           fetch_json "$OWNERS_URL" owners.json "ownership registry"
           fetch_json "$REQS_URL" repo_requirements.json "repo requirements"
 

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -94,8 +94,11 @@ jobs:
           exit 1
 
       - name: Check Protected File Changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$CHANGED_FILES"
           echo ""
@@ -138,7 +141,7 @@ PY
             });
             const latestReviewByUser = new Map();
             for (const review of reviews) {
-              if (!review.user || review.user.login.includes('[bot]')) {
+              if (!review.user || review.user.type === 'Bot') {
                 continue;
               }
               const existing = latestReviewByUser.get(review.user.login);

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -165,7 +165,7 @@ PY
             const ownerFile = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
               .find(file => fs.existsSync(path.join(workspace, file)));
             if (!ownerFile) {
-              core.setFailed('Missing CODEOWNERS');
+              core.setFailed('Missing CODEOWNERS (checked: CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS)');
               return;
             }
 
@@ -175,6 +175,8 @@ PY
               const line = rawLine.replace(/#.*/, '').trim();
               if (!line) continue;
               for (const token of line.split(/\s+/).slice(1)) {
+                // Enforce individual @username identities only; team owners (@org/team)
+                // are excluded because reviewer-to-team membership cannot be resolved here.
                 if (!token.startsWith('@') || token.includes('/')) continue;
                 individualOwners.add(token.slice(1).toLowerCase());
               }

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -16,63 +16,79 @@ on:
       - production
       - 'release/**'
 
-env:
-  GOVERNANCE_REF: 83a7d1da1cfa5041f18450a6d43ff336068285de
-
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   governance:
     name: PR Governance Check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Fetch Governance Rules
+      - name: Fetch Governance Rules + Repo Requirements
         run: |
-          fetch_file() {
-            local url="$1"
-            local output="$2"
-            local label="$3"
-            curl --fail --show-error --silent --location \
-              --retry 5 \
-              --retry-delay 2 \
-              --retry-max-time 30 \
-              --retry-all-errors \
-              "$url" -o "$output" || {
-                echo "::error::Unable to fetch ${label}: $url"
-                exit 1
-              }
-          }
+          # Public distribution repo (rules are signed; safe to publish)
+          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/rules.json" -o rules.json
+          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/CANON_PUBLIC_KEY" -o CANON_PUBLIC_KEY
+          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/repo_requirements.json" -o repo_requirements.json
 
-          # Pin governance artifacts to immutable revision for stable trust root.
-          fetch_file "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/rules.json" "rules.json" "governance rules"
-
-      - name: Verify Rules Signature
+      - name: Determine Repo Tier
+        id: tier
+        shell: bash
         run: |
-          SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
-          if [[ -z "$SIGNATURE" ]]; then
-            echo "::error::Governance rules are NOT SIGNED. Human must run sign-rules.sh and publish CANON_PUBLIC_KEY + signed rules.json."
-            exit 1
+          set -euo pipefail
+          FULL_REPO="${GITHUB_REPOSITORY}"
+          tier=$(jq -r --arg repo "$FULL_REPO" '
+            def glob_to_re($g):
+              "^" + ($g
+                | gsub("\\."; "\\\\.")
+                | gsub("\\*\\*"; ".*")
+                | gsub("\\*"; "[^/]*")
+              ) + "$";
+            .repos
+            | map(. + { re: (glob_to_re(.repo)) })
+            | map(select($repo | test(.re)))
+            | .[0].tier // 99
+          ' repo_requirements.json 2>/dev/null || echo "99")
+          echo "tier=$tier" >> "$GITHUB_OUTPUT"
+          if [[ "$tier" -le 1 ]]; then
+            echo "::notice::Repo tier=${tier} (strict governance)"
+          else
+            echo "::notice::Repo tier=${tier} (bootstrap governance allowed)"
           fi
 
-          CANON_KEY_FILE="governance/CANON_PUBLIC_KEY"
-          if [[ ! -f "$CANON_KEY_FILE" ]]; then
-            echo "::error::Missing trusted governance public key at ${CANON_KEY_FILE}"
-            exit 1
+      - name: Verify Rules Signature (Phased)
+        shell: bash
+        run: |
+          set -euo pipefail
+          tier='${{ steps.tier.outputs.tier }}'
+          SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
+
+          if [[ -z "$SIGNATURE" ]]; then
+            if [[ "$tier" -le 1 ]]; then
+              echo "::error::Governance rules are NOT SIGNED. Tier ${tier} requires signed rules. Human must run sign-rules.sh and publish CANON_PUBLIC_KEY + signed rules.json."
+              exit 1
+            fi
+            echo "::warning::Governance rules are NOT SIGNED. Continuing in bootstrap mode (Tier ${tier})."
+            exit 0
           fi
 
           CANONICAL=$(jq -cS 'del(.signature.signature) | del(.signature.signed_at)' rules.json)
           echo -n "$CANONICAL" > canonical.json
           echo "$SIGNATURE" | base64 -d > signature.bin
 
-          openssl pkeyutl -verify -pubin -inkey "$CANON_KEY_FILE" -sigfile signature.bin -in canonical.json
+          if openssl pkeyutl -verify -pubin -inkey CANON_PUBLIC_KEY -sigfile signature.bin -in canonical.json; then
+            echo "::notice::Governance rules signature VERIFIED"
+            exit 0
+          fi
+
+          echo "::error::Governance rules signature INVALID. Rules may have been tampered with."
+          exit 1
 
       - name: Require CODEOWNERS
         run: |
@@ -83,122 +99,61 @@ jobs:
           exit 1
 
       - name: Check Protected File Changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
         run: |
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          set -euo pipefail
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
           echo "Changed files:"
           echo "$CHANGED_FILES"
           echo ""
 
-          VIOLATIONS=$(
-            CHANGED_FILES="$CHANGED_FILES" python3 - <<'PY'
-import json
-import os
-import sys
-from pathlib import PurePosixPath
+          # If rules are unsigned, fall back to a minimal bootstrap set.
+          SIGNATURE=$(jq -r '.signature.signature // empty' rules.json)
+          if [[ -z "$SIGNATURE" ]]; then
+            PROTECTED_PATTERNS=$(cat <<'EOF'
+.github/workflows/**
+.github/CODEOWNERS
+CODEOWNERS
+governance/**
+EOF
+            )
+          else
+            PROTECTED_PATTERNS=$(jq -r '.rules.protected_files.files[]' rules.json)
+          fi
+          VIOLATIONS=""
 
-changed_files = [line for line in os.environ.get("CHANGED_FILES", "").splitlines() if line]
-try:
-    with open("rules.json", "r", encoding="utf-8") as f:
-        rules = json.load(f)
-except FileNotFoundError:
-    print("Missing rules.json", file=sys.stderr)
-    sys.exit(2)
-except json.JSONDecodeError as exc:
-    print(f"Invalid rules.json: {exc}", file=sys.stderr)
-    sys.exit(2)
-
-protected_patterns = rules.get("rules", {}).get("protected_files", {}).get("files", [])
-violations = []
-
-for pattern in protected_patterns:
-    for file in changed_files:
-        if PurePosixPath(file).match(pattern):
-            violations.append(f"{file} matches protected pattern: {pattern}")
-
-print("\n".join(violations))
-PY
-          )
+          for pattern in $PROTECTED_PATTERNS; do
+            REGEX=$(echo "$pattern" | sed 's/\*\*/.*/' | sed 's/\*/.*/g')
+            while IFS= read -r file; do
+              if [[ "$file" =~ $REGEX ]]; then
+                VIOLATIONS="${VIOLATIONS}${file} matches protected pattern: ${pattern}\n"
+              fi
+            done <<< "$CHANGED_FILES"
+          done
 
           if [[ -n "$VIOLATIONS" ]]; then
             echo "::warning::Protected files modified (extra scrutiny required):"
-            echo "$VIOLATIONS"
+            echo -e "$VIOLATIONS"
           fi
 
       - name: Require Human Approval
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+            const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100
+              pull_number: context.payload.pull_request.number
             });
-            const latestReviewByUser = new Map();
-            for (const review of reviews) {
-              if (!review.user || review.user.type === 'Bot') {
-                continue;
-              }
-              const existing = latestReviewByUser.get(review.user.login);
-              if (
-                !existing ||
-                new Date(review.submitted_at).getTime() > new Date(existing.submitted_at).getTime()
-              ) {
-                latestReviewByUser.set(review.user.login, review);
-              }
-            }
-            const humanApprovals = Array.from(latestReviewByUser.values()).filter(
-              review => review.state === 'APPROVED'
-            );
+            const humanApprovals = reviews.filter(r => r.state === 'APPROVED' && !r.user.login.includes('[bot]'));
             const required = 1;
             if (humanApprovals.length < required) {
               core.setFailed(`Requires at least ${required} human approval(s). Current: ${humanApprovals.length}`);
-              return;
-            }
-
-            const workspace = process.env.GITHUB_WORKSPACE || '.';
-            const ownerFile = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS']
-              .find(file => fs.existsSync(path.join(workspace, file)));
-            if (!ownerFile) {
-              core.setFailed('Missing CODEOWNERS (checked: CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS)');
-              return;
-            }
-
-            const ownerContent = fs.readFileSync(path.join(workspace, ownerFile), 'utf8');
-            const individualOwners = new Set();
-            for (const rawLine of ownerContent.split('\n')) {
-              const line = rawLine.replace(/#.*/, '').trim();
-              if (!line) continue;
-              for (const token of line.split(/\s+/).slice(1)) {
-                // Enforce individual @username identities only; team owners (@org/team)
-                // are excluded because reviewer-to-team membership cannot be resolved here.
-                if (!token.startsWith('@') || token.includes('/')) continue;
-                individualOwners.add(token.slice(1).toLowerCase());
-              }
-            }
-
-            if (individualOwners.size === 0) {
-              core.setFailed(`No individual CODEOWNERS entries found in ${ownerFile}; add at least one @username owner for enforcement.`);
-              return;
-            }
-
-            const codeOwnerApprovals = humanApprovals.filter(review =>
-              individualOwners.has(review.user.login.toLowerCase())
-            );
-            if (codeOwnerApprovals.length < 1) {
-              core.setFailed('Requires at least 1 approval from an individual CODEOWNER listed in CODEOWNERS.');
             }
 
   hardening:
     name: Portfolio Hardening Check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -211,57 +166,13 @@ PY
           set -euo pipefail
           fail() { echo "::error::$1"; exit 1; }
           warn() { echo "::warning::$1"; }
-          fetch_json() {
-            local url="$1"
-            local output="$2"
-            local label="$3"
-            curl --fail --show-error --silent --location \
-              --retry 5 \
-              --retry-delay 2 \
-              --retry-max-time 30 \
-              --retry-all-errors \
-              "$url" -o "$output" || fail "Unable to fetch ${label}: $url"
-          }
 
-          OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/owners.json"
-          REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/repo_requirements.json"
-          fetch_json "$OWNERS_URL" owners.json "ownership registry"
-          fetch_json "$REQS_URL" repo_requirements.json "repo requirements"
-          jq -e 'type == "object"' owners.json >/dev/null || fail "Invalid ownership registry JSON"
-          jq -e 'type == "object"' repo_requirements.json >/dev/null || fail "Invalid repo requirements JSON"
+          OWNERS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/owners.json"
+          REQS_URL="https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/repo_requirements.json"
+          curl -sL "$OWNERS_URL" -o owners.json || fail "Unable to fetch ownership registry: $OWNERS_URL"
+          curl -sL "$REQS_URL" -o repo_requirements.json || fail "Unable to fetch repo requirements: $REQS_URL"
 
-          if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
-            fail "Missing SECURITY.md"
-          fi
-          DOTENV_FILES=$(git ls-files | grep -E '(^|/)\.env(\..+)?$' || true)
-          if [[ -n "$DOTENV_FILES" ]]; then
-            fail "Tracked .env file(s) detected: ${DOTENV_FILES//$'\n'/, }"
-          fi
-          if git ls-files | grep -qE '(^|/)node_modules/'; then
-            fail "Tracked node_modules detected"
-          fi
-          if git ls-files | grep -qE '(^|/)\.wrangler/'; then
-            fail "Tracked .wrangler detected"
-          fi
-          if [[ -f "package.json" ]]; then
-            LOCKS=0
-            [[ -f "package-lock.json" ]] && LOCKS=$((LOCKS+1))
-            [[ -f "pnpm-lock.yaml" ]] && LOCKS=$((LOCKS+1))
-            [[ -f "yarn.lock" ]] && LOCKS=$((LOCKS+1))
-            if [[ "$LOCKS" -eq 0 ]]; then
-              fail "package.json present but no lockfile found"
-            fi
-          fi
-
-          # Eligibility gating (warn-only until registry is populated)
-          OWNERS_FILE=""
-          [[ -f "CODEOWNERS" ]] && OWNERS_FILE="CODEOWNERS"
-          [[ -z "$OWNERS_FILE" && -f ".github/CODEOWNERS" ]] && OWNERS_FILE=".github/CODEOWNERS"
-          [[ -z "$OWNERS_FILE" && -f "docs/CODEOWNERS" ]] && OWNERS_FILE="docs/CODEOWNERS"
-          [[ -n "$OWNERS_FILE" ]] || exit 0
-          PRINCIPALS=$(sed 's/#.*$//' "$OWNERS_FILE" | tr '\t' ' ' | tr ' ' '\n' | grep '^@' | sort -u || true)
-          [[ -n "$PRINCIPALS" ]] || exit 0
-
+          # Determine tier (unknown repos default to tier 99)
           FULL_REPO="${GITHUB_REPOSITORY}"
           REQUIREMENT=$(jq -c --arg repo "$FULL_REPO" '
             def glob_to_re($g):
@@ -276,7 +187,57 @@ PY
             | .[0] // empty
           ' repo_requirements.json)
 
-          [[ -n "$REQUIREMENT" ]] || exit 0
+          tier=99
+          if [[ -n "$REQUIREMENT" ]]; then
+            tier=$(echo "$REQUIREMENT" | jq -r '.tier // 99')
+          fi
+
+          # Tiered enforcement: hard-fail Tier 0/1 first; warn elsewhere (except secrets/supply-chain hard fails).
+          if [[ ! -f "SECURITY.md" && ! -f ".github/SECURITY.md" ]]; then
+            if [[ "$tier" -le 1 ]]; then
+              fail "Missing SECURITY.md (Tier ${tier})"
+            else
+              warn "Missing SECURITY.md (Tier ${tier})"
+            fi
+          fi
+          if git ls-files --error-unmatch .env >/dev/null 2>&1; then
+            fail "Tracked .env detected"
+          fi
+          if git ls-files | grep -qE '(^|/)node_modules/'; then
+            fail "Tracked node_modules detected"
+          fi
+          if git ls-files | grep -qE '(^|/)\\.wrangler/'; then
+            fail "Tracked .wrangler detected"
+          fi
+          if [[ -f "package.json" ]]; then
+            LOCKS=0
+            [[ -f "package-lock.json" ]] && LOCKS=$((LOCKS+1))
+            [[ -f "pnpm-lock.yaml" ]] && LOCKS=$((LOCKS+1))
+            [[ -f "yarn.lock" ]] && LOCKS=$((LOCKS+1))
+            if [[ "$LOCKS" -eq 0 ]]; then
+              if [[ "$tier" -le 1 ]]; then
+                fail "package.json present but no lockfile found (Tier ${tier})"
+              else
+                warn "package.json present but no lockfile found (Tier ${tier})"
+              fi
+            fi
+          fi
+
+          # Eligibility gating (warn-only for Tier 2+; fail for Tier 0/1)
+          OWNERS_FILE="CODEOWNERS"
+          [[ -f ".github/CODEOWNERS" ]] && OWNERS_FILE=".github/CODEOWNERS"
+          if [[ ! -f "$OWNERS_FILE" ]]; then
+            if [[ "$tier" -le 1 ]]; then
+              fail "Missing CODEOWNERS (Tier ${tier})"
+            else
+              warn "Missing CODEOWNERS (Tier ${tier})"
+              exit 0
+            fi
+          fi
+          PRINCIPALS=$(sed 's/#.*$//' "$OWNERS_FILE" | tr '\t' ' ' | tr ' ' '\n' | grep '^@' | sort -u || true)
+          [[ -n "$PRINCIPALS" ]] || exit 0
+
+          [[ -n "$REQUIREMENT" ]] || { warn "No repo_requirements entry for ${FULL_REPO}; skipping eligibility gating"; exit 0; }
 
           REQ_TY=$(echo "$REQUIREMENT" | jq -r '.requires.ty[]?' 2>/dev/null || true)
           REQ_VY=$(echo "$REQUIREMENT" | jq -r '.requires.vy[]?' 2>/dev/null || true)
@@ -311,7 +272,11 @@ PY
             [[ -z "$principal" ]] && continue
             row=$(jq -c --arg gh "$principal" '.principals[]? | select(.github==$gh)' owners.json || true)
             if [[ -z "$row" ]]; then
-              warn "CODEOWNERS principal missing from registry: $principal"
+              if [[ "$tier" -le 1 ]]; then
+                fail "CODEOWNERS principal missing from registry: $principal (Tier ${tier})"
+              else
+                warn "CODEOWNERS principal missing from registry: $principal (Tier ${tier})"
+              fi
               continue
             fi
             ok="true"
@@ -334,6 +299,10 @@ PY
               fi
             done
             if [[ "$ok" != "true" ]]; then
-              warn "CODEOWNERS principal fails TY/VY/RY eligibility: $principal"
+              if [[ "$tier" -le 1 ]]; then
+                fail "CODEOWNERS principal fails TY/VY/RY eligibility: $principal (Tier ${tier})"
+              else
+                warn "CODEOWNERS principal fails TY/VY/RY eligibility: $principal (Tier ${tier})"
+              fi
             fi
           done <<< "$PRINCIPALS"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Fetch Governance Rules
         run: |
           # Public distribution repo (rules are signed; safe to publish)
-          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/rules.json" -o rules.json
-          curl -sL "https://raw.githubusercontent.com/chittyfoundation/.github/main/governance/CANON_PUBLIC_KEY" -o CANON_PUBLIC_KEY
+          # Pin to an immutable upstream revision so rules.json and CANON_PUBLIC_KEY
+          # cannot both be replaced via changes to a moving branch ref.
+          GOVERNANCE_REF="0123456789abcdef0123456789abcdef01234567"
+          curl -fsSL "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/rules.json" -o rules.json
+          curl -fsSL "https://raw.githubusercontent.com/chittyfoundation/.github/${GOVERNANCE_REF}/governance/CANON_PUBLIC_KEY" -o CANON_PUBLIC_KEY
 
       - name: Verify Rules Signature
         run: |

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -130,7 +130,7 @@ jobs:
           if git ls-files | grep -qE '(^|/)node_modules/'; then
             fail "Tracked node_modules detected"
           fi
-          if git ls-files | grep -qE '(^|/)\\.wrangler/'; then
+          if git ls-files | grep -qE '(^|/)\.wrangler/'; then
             fail "Tracked .wrangler detected"
           fi
           if [[ -f "package.json" ]]; then

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -155,8 +155,11 @@ jobs:
           fi
 
           # Eligibility gating (warn-only until registry is populated)
-          OWNERS_FILE="CODEOWNERS"
-          [[ -f ".github/CODEOWNERS" ]] && OWNERS_FILE=".github/CODEOWNERS"
+          OWNERS_FILE=""
+          [[ -f "CODEOWNERS" ]] && OWNERS_FILE="CODEOWNERS"
+          [[ -z "$OWNERS_FILE" && -f ".github/CODEOWNERS" ]] && OWNERS_FILE=".github/CODEOWNERS"
+          [[ -z "$OWNERS_FILE" && -f "docs/CODEOWNERS" ]] && OWNERS_FILE="docs/CODEOWNERS"
+          [[ -n "$OWNERS_FILE" ]] || exit 0
           PRINCIPALS=$(sed 's/#.*$//' "$OWNERS_FILE" | tr '\t' ' ' | tr ' ' '\n' | grep '^@' | sort -u || true)
           [[ -n "$PRINCIPALS" ]] || exit 0
 


### PR DESCRIPTION
Adds SHA-pinned Governance workflow calling CHITTYFOUNDATION/chittycanon and enables Portfolio Hardening.\n\n- Required for CF Workers Builds portfolios.\n- Enforces CODEOWNERS + hardening gates.\n- Governance SHA: 83a7d1da1cfa5041f18450a6d43ff336068285de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated governance workflow enforcing at least one human approval, tiered signature verification when present, and warnings for protected-file changes.
  * Added repository hardening checks that enforce security documentation, prevent tracked sensitive files, and validate dependency lockfile presence per tier.
  * Assigned repository-wide ownership to a designated maintainer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->