### PR TITLE
fix(ci): suppress chitty.cc network calls during vitest

### DIFF
--- a/server/lib/discovery-client.ts
+++ b/server/lib/discovery-client.ts
@@ -7,6 +7,7 @@ interface DiscoveryEnv {
   CHITTY_AUTH_SERVICE_TOKEN?: string;
   CHITTYCONNECT_API_TOKEN?: string;
   CHITTYCONNECT_SERVICE_TOKEN?: string;
+  CHITTY_ENV?: string;
 }
 
 const DISCOVERY_BASE = 'https://discovery.chitty.cc';
@@ -19,6 +20,8 @@ function getToken(env: DiscoveryEnv): string | undefined {
 }
 
 export async function registerWithDiscovery(env: DiscoveryEnv): Promise<boolean> {
+  if (env.CHITTY_ENV === 'test') return false;
+
   const token = getToken(env);
   if (!token) {
     console.warn('[discovery-client] No service token available — skipping registration');
@@ -71,6 +74,8 @@ export async function registerWithDiscovery(env: DiscoveryEnv): Promise<boolean>
 }
 
 export async function sendHeartbeat(env: DiscoveryEnv): Promise<boolean> {
+  if (env.CHITTY_ENV === 'test') return false;
+
   const token = getToken(env);
   if (!token) return false;
 

--- a/server/lib/ledger-client.ts
+++ b/server/lib/ledger-client.ts
@@ -26,6 +26,7 @@ interface LedgerEnv {
   CHITTY_LEDGER_BASE?: string;
   CHITTY_AUTH_SERVICE_TOKEN?: string;
   CHITTYCONNECT_API_TOKEN?: string;
+  CHITTY_ENV?: string;
 }
 
 // ── Resolution ──
@@ -34,6 +35,8 @@ let _cached: { url: string; expires: number } | null = null;
 
 export async function resolveLedgerBase(env: LedgerEnv): Promise<string> {
   if (env.CHITTY_LEDGER_BASE) return env.CHITTY_LEDGER_BASE.replace(/\/$/, '');
+
+  if (env.CHITTY_ENV === 'test') return 'https://ledger.chitty.cc';
 
   if (_cached && _cached.expires > Date.now()) return _cached.url;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['**/*.test.{ts,tsx}'],
     exclude: ['dist/**', 'node_modules/**'],
+    env: {
+      // Prevent real network calls to chitty.cc during test runs.
+      // ledger-client skips registry.chitty.cc lookup when CHITTY_LEDGER_BASE is set.
+      // discovery-client skips self-registration when CHITTY_ENV is 'test'.
+      CHITTY_LEDGER_BASE: 'https://ledger.chitty.cc',
+      CHITTY_ENV: 'test',
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- `discovery-client`: add `CHITTY_ENV=test` guard in `registerWithDiscovery` and `sendHeartbeat` — prevents live POSTs to `discovery.chitty.cc` when a service token is present in test env stubs
- `ledger-client`: add `CHITTY_ENV=test` guard in `resolveLedgerBase` — skips `registry.chitty.cc` lookup and goes straight to hardcoded default (same result as registry-unavailable path, no behavior change)
- `vitest.config.ts`: set `CHITTY_LEDGER_BASE` and `CHITTY_ENV=test` in `test.env` so both guards activate globally without per-test env setup

## Root cause

Copilot's firewall report on PR #95 ([comment](https://github.com/chittyapps/chittyfinance/pull/95#issuecomment-4272225610)) showed `vitest` triggering DNS blocks on three addresses. The calls came from:

1. `status.test.ts` invoking `worker.fetch()` with `CHITTY_AUTH_SERVICE_TOKEN` in env — worker calls `discoveryRegister()`, `getToken()` succeeds, detached promise hits `discovery.chitty.cc`
2. Any test importing `ledger-client` without `CHITTY_LEDGER_BASE` set — `resolveLedgerBase()` fetches `registry.chitty.cc` at first call; module-level `_cached` means this fires once per test worker process
3. After registry is blocked, fallback to `ledger.chitty.cc` and `postLedgerEntry` attempts a real POST

## Production safety

`CHITTY_ENV` is not set in Cloudflare Workers environments. All guards are dead code in production.

## Test plan

- [ ] `vitest` run passes with no DNS errors
- [ ] `ledger-client.test.ts` — existing fetch spy tests continue to pass
- [ ] `status.test.ts` — worker health/status routes return 200; no discovery call fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to prevent network calls during test runs by injecting test-specific environment variables and adding early returns for test mode in service clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->