### PR TITLE
feat(copilot): add MCP servers — chitty gateway + chittyevidence-ksn AI Search

### DIFF
--- a/.github/copilot-mcp.json
+++ b/.github/copilot-mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "chitty": {
+      "type": "http",
+      "url": "https://ch1tty.com/mcp",
+      "tools": ["*"]
+    },
+    "chittyevidence-ksn": {
+      "type": "http",
+      "url": "https://ae39deba-9bcc-4613-8139-edbcc7603180.search.ai.cloudflare.com/mcp",
+      "tools": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-mcp.json` to configure MCP servers for the Copilot coding agent
- **chitty**: Ch1tty gateway at `ch1tty.com/mcp` (OAuth-protected, full ChittyOS tool access)
- **chittyevidence-ksn**: Cloudflare AI Search public MCP endpoint for KSN HOA evidence (Cases 20261701239 + 20261701287)

## Why AI Search, not AutoRAG

Reviewed `cloudflare/mcp-server-cloudflare/apps/autorag` source. That server targets the older AutoRAG API (`/accounts/{id}/autorag/rags/{rag_id}/search`). The `chittyevidence-ksn` instance is a Cloudflare **AI Search** instance (new product), which exposes its own built-in MCP endpoint directly — no separate MCP server needed.

AI Search instance features:
- Hybrid BM25+vector search (RRF fusion)
- Reranking via `@cf/baai/bge-reranker-base`
- Custom metadata schema: `case`, `property`, `hoa`, `doc_type`, `ingested_at`
- Data source: `r2:chittyevidence-documents/incoming`

## Test plan

- [ ] Copilot coding agent session sees both MCP servers
- [ ] `chittyevidence-ksn` search tool returns results for KSN HOA evidence queries
- [ ] No schema validation errors in GitHub Copilot settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for MCP HTTP server integrations to establish connections with external service endpoints. This provides access to additional tools and capabilities that extend the application's functionality. These new integrations enable enhanced features, improved service connections, and expanded integration support for a better overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->