### PR TITLE
feat: Cloudflare Email Service (replaces SendGrid)

### DIFF
--- a/deploy/system-wrangler.toml
+++ b/deploy/system-wrangler.toml
@@ -28,6 +28,17 @@ routes = [
   { pattern = "finance.chitty.cc/*", zone_name = "chitty.cc" }
 ]
 
+# Hyperdrive binding for fractal scope projection into ChittyOS-Core
+[[hyperdrive]]
+binding = "CHITTYOS_CORE_DB"
+id = "1d126444cff1416cb415447e6cc6d15a"
+
+# Cloudflare Email Service binding (beta, Workers Paid plan)
+# Domain: chitty.cc — onboard at dashboard → Email Sending
+[[send_email]]
+name = "EMAIL"
+allowed_sender_addresses = ["finance@chitty.cc", "noreply@chitty.cc"]
+
 [vars]
 MODE = "system"
 NODE_ENV = "production"
@@ -77,6 +88,9 @@ new_sqlite_classes = ["ChittyAgent"]
 [env.dev]
 name = "chittyfinance-dev"
 workers_dev = true
+
+[[env.dev.send_email]]
+name = "EMAIL"
 
 [env.dev.vars]
 MODE = "system"
@@ -143,6 +157,10 @@ workers_dev = false
 routes = [
   { pattern = "finance.chitty.cc/*", zone_name = "chitty.cc" }
 ]
+
+[[env.production.send_email]]
+name = "EMAIL"
+allowed_sender_addresses = ["finance@chitty.cc", "noreply@chitty.cc"]
 
 [env.production.vars]
 MODE = "system"

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,6 +38,7 @@ import { leaseRoutes } from './routes/leases';
 import { chittyIdAuthRoutes } from './routes/chittyid-auth';
 import { allocationRoutes } from './routes/allocations';
 import { classificationRoutes } from './routes/classification';
+import { emailRoutes } from './routes/email';
 import { createDb } from './db/connection';
 import { SystemStorage } from './storage/system';
 
@@ -131,6 +132,7 @@ export function createApp() {
   app.route('/', taxRoutes);
   app.route('/', allocationRoutes);
   app.route('/', classificationRoutes);
+  app.route('/', emailRoutes);
   app.route('/', googleRoutes);
   app.route('/', commsRoutes);
   app.route('/', workflowRoutes);

--- a/server/env.ts
+++ b/server/env.ts
@@ -35,7 +35,7 @@ export interface Env {
   TWILIO_ACCOUNT_SID?: string;
   TWILIO_AUTH_TOKEN?: string;
   TWILIO_PHONE_NUMBER?: string;
-  // SendGrid email
+  // SendGrid email (deprecated — replaced by Cloudflare Email Service binding)
   SENDGRID_API_KEY?: string;
   SENDGRID_FROM_EMAIL?: string;
   // ChittyID OAuth
@@ -48,6 +48,7 @@ export interface Env {
   FINANCE_KV: KVNamespace;
   FINANCE_R2: R2Bucket;
   ASSETS: Fetcher;
+  EMAIL?: SendEmail;
   // CF_AGENT: DurableObjectNamespace; // Disabled — DO being rebuilt
 }
 

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -1,0 +1,118 @@
+/**
+ * Email service using Cloudflare Email Service (beta).
+ * Replaces SendGrid for transactional email.
+ *
+ * Sender addresses: finance@chitty.cc, noreply@chitty.cc
+ * Domain: chitty.cc (onboarded via Cloudflare dashboard)
+ */
+
+import type { Env } from '../env';
+
+interface EmailOptions {
+  to: string | string[];
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+  replyTo?: string;
+  cc?: string[];
+  bcc?: string[];
+}
+
+const DEFAULT_FROM = { email: 'finance@chitty.cc', name: 'ChittyFinance' };
+
+/**
+ * Send a transactional email via Cloudflare Email Service.
+ * Falls back silently if EMAIL binding is not configured.
+ */
+export async function sendEmail(env: Env, options: EmailOptions): Promise<{ sent: boolean; messageId?: string; error?: string }> {
+  if (!env.EMAIL) {
+    console.warn('[email] EMAIL binding not configured — skipping send');
+    return { sent: false, error: 'email_not_configured' };
+  }
+
+  try {
+    const result = await env.EMAIL.send({
+      to: options.to,
+      from: options.from ? { email: options.from, name: 'ChittyFinance' } : DEFAULT_FROM,
+      subject: options.subject,
+      html: options.html,
+      text: options.text,
+      cc: options.cc,
+      bcc: options.bcc,
+      replyTo: options.replyTo ?? 'nick@aribia.llc',
+    });
+
+    return { sent: true, messageId: result.messageId };
+  } catch (e: any) {
+    console.error('[email] Send failed:', e.code, e.message);
+    return { sent: false, error: e.message };
+  }
+}
+
+// ── Email templates ──
+
+export function leaseExpirationEmail(tenantName: string, propertyName: string, unitName: string, expiresAt: string, daysLeft: number): EmailOptions {
+  return {
+    to: 'nick@aribia.llc',
+    subject: `Lease expiring in ${daysLeft} days — ${propertyName} ${unitName}`,
+    html: `
+      <h2>Lease Expiration Notice</h2>
+      <p><strong>Property:</strong> ${propertyName}</p>
+      <p><strong>Unit:</strong> ${unitName}</p>
+      <p><strong>Tenant:</strong> ${tenantName}</p>
+      <p><strong>Expires:</strong> ${expiresAt} (${daysLeft} days)</p>
+      <p>Review at <a href="https://finance.chitty.cc/properties">ChittyFinance</a>.</p>
+    `,
+    text: `Lease expiring: ${propertyName} ${unitName} — ${tenantName} — ${expiresAt} (${daysLeft} days)`,
+  };
+}
+
+export function classificationAlertEmail(count: number, tenantName: string): EmailOptions {
+  return {
+    to: 'nick@aribia.llc',
+    subject: `${count} transactions need classification — ${tenantName}`,
+    html: `
+      <h2>Classification Queue</h2>
+      <p><strong>${count}</strong> transactions in <strong>${tenantName}</strong> are pending classification (COA code 9010 — Suspense).</p>
+      <p>Review at <a href="https://finance.chitty.cc/classification">ChittyFinance Classification</a>.</p>
+    `,
+    text: `${count} transactions need classification in ${tenantName}. Review at finance.chitty.cc/classification`,
+  };
+}
+
+export function webhookIngestionEmail(source: string, count: number, tenantName: string): EmailOptions {
+  return {
+    to: 'nick@aribia.llc',
+    subject: `${count} ${source} transactions ingested — ${tenantName}`,
+    html: `
+      <h2>${source} Webhook Ingestion</h2>
+      <p><strong>${count}</strong> new transactions ingested for <strong>${tenantName}</strong>.</p>
+      <p>Review at <a href="https://finance.chitty.cc/transactions">ChittyFinance</a>.</p>
+    `,
+    text: `${count} ${source} transactions ingested for ${tenantName}`,
+  };
+}
+
+export function dailySummaryEmail(stats: {
+  totalTransactions: number;
+  suspenseCount: number;
+  expiringLeases: number;
+  entities: string[];
+}): EmailOptions {
+  return {
+    to: 'nick@aribia.llc',
+    subject: `Daily Finance Summary — ${new Date().toISOString().slice(0, 10)}`,
+    html: `
+      <h2>Daily Finance Summary</h2>
+      <table style="border-collapse:collapse;width:100%">
+        <tr><td style="padding:4px 8px;border-bottom:1px solid #eee"><strong>Total transactions</strong></td><td style="padding:4px 8px;border-bottom:1px solid #eee">${stats.totalTransactions}</td></tr>
+        <tr><td style="padding:4px 8px;border-bottom:1px solid #eee"><strong>Pending classification</strong></td><td style="padding:4px 8px;border-bottom:1px solid #eee">${stats.suspenseCount}</td></tr>
+        <tr><td style="padding:4px 8px;border-bottom:1px solid #eee"><strong>Expiring leases</strong></td><td style="padding:4px 8px;border-bottom:1px solid #eee">${stats.expiringLeases}</td></tr>
+        <tr><td style="padding:4px 8px"><strong>Active entities</strong></td><td style="padding:4px 8px">${stats.entities.join(', ')}</td></tr>
+      </table>
+      <p><a href="https://finance.chitty.cc">Open ChittyFinance</a></p>
+    `,
+    text: `Daily summary: ${stats.totalTransactions} txns, ${stats.suspenseCount} pending classification, ${stats.expiringLeases} expiring leases`,
+  };
+}

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono';
+import type { HonoEnv } from '../env';
+import { sendEmail } from '../lib/email';
+
+export const emailRoutes = new Hono<HonoEnv>();
+
+// POST /api/email/test — send a test email (auth required)
+emailRoutes.post('/api/email/test', async (c) => {
+  const { to, subject, body } = await c.req.json<{ to?: string; subject?: string; body?: string }>();
+
+  const result = await sendEmail(c.env, {
+    to: to ?? 'nick@aribia.llc',
+    subject: subject ?? 'ChittyFinance Test Email',
+    html: body ?? '<h2>Test</h2><p>Email service is working.</p>',
+    text: 'Test — email service is working.',
+  });
+
+  return c.json(result);
+});
+
+// GET /api/email/status — check if email binding is configured
+emailRoutes.get('/api/email/status', async (c) => {
+  return c.json({
+    configured: !!c.env.EMAIL,
+    sender: 'finance@chitty.cc',
+    service: 'cloudflare-email-service',
+  });
+});


### PR DESCRIPTION
## Summary
- Replace SendGrid with Cloudflare Email Service (native Workers binding)
- `env.EMAIL.send()` — no API keys, no external SMTP
- Email templates: lease expiration, classification alerts, webhook ingestion, daily summary
- Test endpoint: `POST /api/email/test`, status: `GET /api/email/status`
- Senders: `finance@chitty.cc`, `noreply@chitty.cc`
- 3,000 free/month, $0.35/1K after (Workers Paid plan, beta)

## Setup required
- [ ] Onboard `chitty.cc` in Cloudflare dashboard → Email Sending
- [ ] DNS records (SPF/DKIM/DMARC) auto-provisioned on onboarding
- [ ] Send test email via `POST /api/email/test`

## Test plan
- [x] `GET /api/email/status` returns `{"configured": true}`
- [x] Deployed and verified binding is active
- [ ] Send test email after domain onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Cloudflare Email Service for sending transactional emails
  * Added email API endpoints: test endpoint and service status check
  * Added email templates for lease expiration alerts, transaction notifications, webhook ingestion, and daily summaries

* **Chores**
  * Migrated email provider from SendGrid to Cloudflare Email Service
  * Updated deployment configuration with email service bindings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->