### PR TITLE
feat: inbound email handler for finance@chitty.cc

### DIFF
--- a/server/worker.ts
+++ b/server/worker.ts
@@ -21,6 +21,47 @@ export default {
       if (!ok) console.warn('[cron:discovery] heartbeat failed');
     }));
   },
+
+  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext) {
+    const from = message.from;
+    const to = message.to;
+    const subject = message.headers.get('subject') || '(no subject)';
+    const messageId = message.headers.get('message-id') || `${Date.now()}`;
+    const size = message.rawSize;
+
+    console.log(`[email:inbound] from=${from} to=${to} subject="${subject}" size=${size}`);
+
+    // Store raw email in R2 for document ingestion pipeline
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const sanitizedId = messageId.replace(/[<>]/g, '').replace(/[^a-zA-Z0-9@._-]/g, '_');
+    const key = `inbound-email/${ts}_${sanitizedId}.eml`;
+
+    const rawBytes = await new Response(message.raw).arrayBuffer();
+    await env.FINANCE_R2.put(key, rawBytes, {
+      customMetadata: {
+        from,
+        to,
+        subject,
+        messageId,
+        receivedAt: new Date().toISOString(),
+        sizeBytes: String(size),
+      },
+    });
+
+    console.log(`[email:inbound] stored in R2: ${key} (${rawBytes.byteLength} bytes)`);
+
+    // Index in KV for quick lookup
+    const kv = env.FINANCE_KV;
+    const indexEntry = JSON.stringify({
+      key,
+      from,
+      to,
+      subject,
+      receivedAt: new Date().toISOString(),
+      sizeBytes: rawBytes.byteLength,
+    });
+    await kv.put(`email:inbound:${ts}`, indexEntry, { expirationTtl: 86400 * 90 }); // 90 days
+  },
 } satisfies ExportedHandler<Env>;
 
 // Re-export the Agent DO class so Wrangler can bind it


### PR DESCRIPTION
## Summary
- Add `email()` handler to Worker for inbound email processing
- Stores raw .eml files in R2 (`inbound-email/<ts>_<msgid>.eml`) with from/to/subject metadata
- Indexes in KV with 90-day TTL for quick lookup
- Requires dashboard action: create Email Routing rule for `finance@chitty.cc` → `chittyfinance` Worker

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Deploy Worker and create Email Routing rule in Cloudflare dashboard
- [ ] Send test email to finance@chitty.cc and verify R2 storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added inbound email processing with automatic extraction of sender, recipient, subject, and message identifier information, stored with 90-day retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->