### PR TITLE
feat(wrangler): add SERVICE_SCOPE_DB hyperdrive binding

### DIFF
--- a/deploy/system-wrangler.jsonc
+++ b/deploy/system-wrangler.jsonc
@@ -28,7 +28,8 @@
 
   // Hyperdrive binding for fractal scope projection into ChittyOS-Core
   "hyperdrive": [
-    { "binding": "CHITTYOS_CORE_DB", "id": "1d126444cff1416cb415447e6cc6d15a" }
+    { "binding": "CHITTYOS_CORE_DB", "id": "1d126444cff1416cb415447e6cc6d15a" },
+    { "binding": "SERVICE_SCOPE_DB", "id": "89158b50e55a4d5d9279b5d5c890ea7b" }
   ],
 
   // Cloudflare Email Service binding (beta, Workers Paid plan)
@@ -168,6 +169,10 @@
       ],
       "r2_buckets": [
         { "binding": "FINANCE_R2", "bucket_name": "chittyfinance-storage" }
+      ],
+      "hyperdrive": [
+        { "binding": "CHITTYOS_CORE_DB", "id": "1d126444cff1416cb415447e6cc6d15a" },
+        { "binding": "SERVICE_SCOPE_DB", "id": "89158b50e55a4d5d9279b5d5c890ea7b" }
       ],
       "durable_objects": {
         "bindings": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,9 +27,12 @@
     { "pattern": "finance.chitty.cc/*", "zone_name": "chitty.cc" }
   ],
 
-  // Hyperdrive binding for fractal scope projection into ChittyOS-Core
+  // Hyperdrive bindings for fractal scope projection.
+  // CHITTYOS_CORE_DB → ChittyOS-Core aggregation. SERVICE_SCOPE_DB → service's own authoritative scopes.
+  // Required by chittyschema/identity/scripts/validate-fractal-scopes.ts
   "hyperdrive": [
-    { "binding": "CHITTYOS_CORE_DB", "id": "1d126444cff1416cb415447e6cc6d15a" }
+    { "binding": "CHITTYOS_CORE_DB", "id": "1d126444cff1416cb415447e6cc6d15a" },
+    { "binding": "SERVICE_SCOPE_DB", "id": "89158b50e55a4d5d9279b5d5c890ea7b" }
   ],
 
   // Cloudflare Email Service binding


### PR DESCRIPTION
## Summary
- Adds `SERVICE_SCOPE_DB` Hyperdrive binding (id `89158b50e55a4d5d9279b5d5c890ea7b`) to both `wrangler.jsonc` and `deploy/system-wrangler.jsonc`.
- Pairs with the existing `CHITTYOS_CORE_DB` binding so the fractal scope projector can write authoritative scopes to the service's own DB and project into ChittyOS-Core.
- Required by `chittyschema/identity/scripts/validate-fractal-scopes.ts` (it errors on missing `SERVICE_SCOPE_DB`).
- Removes drift between the two wrangler files (root was missing the binding `deploy/` already had locally).

## Why
The shared scope projector (`@chittyos/schema/scope-projector`, wired in `server/lib/central-workflows.ts` via PR #103) reads `env.SERVICE_SCOPE_DB?.connectionString` and falls back to `SERVICE_SCOPE_DATABASE_URL`. With this binding in place, scope writes go through Hyperdrive instead of the env-var fallback path.

## Validation
```
$ npx tsx identity/scripts/validate-fractal-scopes.ts --wrangler .../chittyfinance/wrangler.jsonc
All checks passed.  (exit 0)

$ npx tsx identity/scripts/validate-fractal-scopes.ts --wrangler .../chittyfinance/deploy/system-wrangler.jsonc
All checks passed.  (exit 0)
```

## Test plan
- [x] validate-fractal-scopes.ts passes for both wrangler files
- [ ] Post-deploy: confirm Worker boot logs show both Hyperdrive bindings resolving
- [ ] Post-deploy: trigger a scope projection and verify a row lands in the service-DB scopes table (in addition to the existing Core projection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new database resource in the production environment for managing service-specific scopes, enabling enhanced scope projection capabilities across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->