### PR TITLE
chore: add project allowlist for read-only gh search and npm view

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh search *)",
+      "Bash(npm view *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds project-level `.claude/settings.json` with read-only allowlist for `gh search *` and `npm view *`
- Reduces permission prompts surfaced by `/fewer-permission-prompts` (8x `gh search`, 3x `npm view` in transcripts)

## Test plan
- [x] File is project-scoped, additive — does not modify `.claude/settings.local.json` (per-developer)
- [x] Allowlist contains only read-only commands; no mutating operations
- [x] No code changes; permissions config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development tooling configuration to manage command permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->