### PR TITLE
chore(charter): absorb ChittyBooks deprecation

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -48,9 +48,16 @@ ChittyFinance is a **full-stack financial management platform** for the ChittyOS
 - Identity generation (ChittyID)
 - Token provisioning (ChittyAuth)
 - Service registration (ChittyRegister)
-- Evidence management (ChittyLedger)
+- Evidence management (ChittyLedger - Evidence projection)
 - Legal case management (ChittyCases)
-- Property management UI for end-users (ChittyBooks consumes ChittyFinance as engine)
+
+ChittyFinance IS the bookkeeping UI for ChittyOS. The former ChittyBooks
+service was deprecated on 2026-05-27 and folded into ChittyFinance — its two
+unique features (AI categorization, AI insights) were already present here at
+higher quality. See `CHITTYAPPS/chittybooks/ARCHIVED.md`.
+
+Ledger writes flow through the ChittyLedger substrate as the "Finance"
+projection (`chittycanon://core/services/chittyledger#projection/finance`).
 
 ## Dual-Mode Operation
 


### PR DESCRIPTION
## Summary

- Removes the "ChittyBooks consumes ChittyFinance as engine" line from CHARTER (no longer aspirational — Finance IS the bookkeeping UI after ChittyBooks deprecation)
- Annotates that ledger writes flow through the ChittyLedger substrate as the **Finance projection** per the canonical Ledger projection model
- Updates "Evidence management" reference to the Evidence projection

## Context

ChittyBooks was deprecated in CHITTYAPPS/chittybooks#2 after a 2026-05-27 substance audit found both of its unique features (AI categorization + AI insights) already present in ChittyFinance at higher quality.

## Source

CHITTYOS/chittymarket docs/remediation/2026-05-27-finance-books-functioning-as-intended.md

## Test plan
- [ ] Charter renders cleanly in canon validator
- [ ] No code/contract change — docs only

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated charter documentation to clarify Finance scope boundaries and explicitly define delegation of Evidence and Legal case management functions to designated systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyapps/chittyfinance/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->