### PR TITLE
docs: finance/books/ledger boundary contracts + proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ server/
   app.ts         Hono factory
   worker.ts      CF Workers entry (prod)
   index.ts       Legacy Express entry (standalone dev — kept for reference)
-  routes/        22 resource-per-file modules. Resource routes are mounted at /api/<resource> (no /v1 prefix). Only operational/meta routes (status, metrics, documentation) live under /api/v1/. OpenAPI spec at /api/v1/documentation is authoritative.
+  routes/        22 resource-per-file modules. Resource routes are mounted at /api/<resource> (no /v1 prefix). Only operational/meta routes (status, metrics, documentation) live under /api/v1/. OpenAPI spec at /api/v1/documentation is partial (covers a subset — see `server/routes/docs.ts`); treat `server/app.ts` route mounts as the source of truth until the spec is completed.
   middleware/    auth (hybridAuth), tenant, error
   storage/       SystemStorage — single source of DB access
   db/            Neon HTTP connection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ server/
   app.ts         Hono factory
   worker.ts      CF Workers entry (prod)
   index.ts       Legacy Express entry (standalone dev — kept for reference)
-  routes/        22 resource-per-file modules. OpenAPI at /api/v1/documentation
+  routes/        22 resource-per-file modules. Resource routes are mounted at /api/<resource> (no /v1 prefix). Only operational/meta routes (status, metrics, documentation) live under /api/v1/. OpenAPI spec at /api/v1/documentation is authoritative.
   middleware/    auth (hybridAuth), tenant, error
   storage/       SystemStorage — single source of DB access
   db/            Neon HTTP connection

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -9,7 +9,7 @@
 | ChittyFinance (engine) | `CHITTYAPPS/chittyfinance` | Hono on CF Workers at `finance.chitty.cc` | `200 ok` |
 | ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `books.chitty.cc` does not resolve. |
 | ChittyLedger (substrate) | `CHITTYFOUNDATION/chittyledger` | Worker at `ledger.chitty.cc` | `200 ok` |
-| ChittyLedger (legacy fork) | `CHITTYOS/chittybooks` | Express + React, in-memory, not deployed | n/a — DUPLICATE, candidate for retirement or repurpose as ChittyLedger-Evidence seed |
+| ChittyLedger (legacy fork) | `CHITTYOS/chittyledger` | Express + React, in-memory, not deployed | n/a — DUPLICATE, candidate for retirement or repurpose as ChittyLedger-Evidence seed (see `docs/proposals/chittyledger-naming-plan.md`) |
 
 `CHITTYAPPS/chittybooks/CHARTER.md` claims a Cloudflare Worker at `books.chitty.cc`. The repository is a Python Flask application with `deploymentTarget = "cloudrun"`. Charter and code disagree.
 
@@ -31,23 +31,23 @@ ChittyBooks MUST NOT write transactions, allocations, or COA classifications dir
 
 ## API Surface ChittyBooks consumes
 
-All paths are under `https://finance.chitty.cc`. Auth: ChittyAuth Bearer token. Tenant: `X-Tenant-ID` header (server-side enforces from JWT claims; path param is not trusted).
+All paths are under `https://finance.chitty.cc`. Auth (per `server/middleware/auth.ts` hybridAuth): either a service `Authorization: Bearer <CHITTY_AUTH_SERVICE_TOKEN>` header (with `X-Chitty-User-Id`) **or** a ChittyAuth-issued JWT delivered as the session cookie (`jwt:` prefix) — Bearer is service-to-service only; user/browser callers use the cookie path. Tenant scoping is resolved server-side from session/JWT claims (`c.var.tenantId`); path params are not trusted.
 
 | Path (verified mounted) | Purpose for ChittyBooks |
 |---|---|
 | `/api/tenants` | List tenants the caller can read |
 | `/api/properties` | Property list |
 | `/api/accounts` | Account list + balances |
-| `/api/transactions` | Transaction feed (filter by date, account, tenant) |
-| `/api/allocations` | Allocation rules + history |
+| `/api/transactions` | Transaction feed for caller's tenant. Today the mounted handler accepts only `?limit=`; `?accountId=` and `?since=` are accepted on `/api/transactions/export`. Any source/date filter parity is a follow-up, not a current guarantee. |
+| `/api/allocations/rules`, `/api/allocations/preview`, `/api/allocations/execute`, `/api/allocations/run` | Allocation rule CRUD + dry-run + execution (per `server/accounting/allocations.ts`). There is no umbrella `/api/allocations` index route. |
 | `/api/classification` | COA assignments + audit trail |
-| `/api/reports/*` | Pre-aggregated bookkeeping views |
-| `/api/integrations/status` | Which connectors are configured |
+| `/api/reports/consolidated`, `/api/workflows/close-tax-automation` | Pre-aggregated bookkeeping/close views currently mounted under `/api/reports/*` and `/api/workflows/*` (per `server/accounting/reports.ts`). A `/api/reports/reconciliation` endpoint is **proposed**, not yet mounted. |
+| `/api/integrations/status` | Per-provider `configured` boolean derived from env vars (see `server/routes/integrations.ts`). Last-sync timestamps are a proposed extension, not part of the current response. |
 | `/api/v1/documentation` | OpenAPI 3.0 spec (note: only the docs route is under `/api/v1`; data routes are under `/api`. See `docs/proposals/api-v1-prefix-fix.md`.) |
 
 ## ChittyLedger projection paths (read-only)
 
-ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` aggregator endpoints — it does not query ChittyLedger directly. This preserves the substrate boundary: ChittyLedger does not know about ChittyBooks.
+ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` aggregator endpoints — it does not query ChittyLedger directly. This preserves the substrate boundary: ChittyLedger does not know about ChittyBooks. The aggregator endpoints (e.g. `/api/ledger/finance/*`) are **proposed** — none are mounted yet. They must be defined and shipped in ChittyFinance before ChittyBooks relies on them. Until then, ChittyBooks reads projection data only through the existing mounted routes above.
 
 ## Deploy decision (2026-05-27)
 

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -49,11 +49,13 @@ All paths are under `https://finance.chitty.cc`. Auth: ChittyAuth Bearer token. 
 
 ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` aggregator endpoints — it does not query ChittyLedger directly. This preserves the substrate boundary: ChittyLedger does not know about ChittyBooks.
 
-## Deploy decision (DECISION, 2026-05-27)
+## Deploy decision (2026-05-27)
 
-**Chosen: retire `chittybooks.chitty.cc` as a separate deployable. ChittyBooks becomes a UI surface served by ChittyFinance.**
+**Retired: the assumption that `chittybooks.chitty.cc` is a live API.** The domain does not resolve and no Worker exists. Code paths that target it MUST be disabled or guarded (see `docs/proposals/ch1tty-connector-revision.md`).
 
-Proof from repo files (no inference):
+**Not yet decided: the actual ChittyBooks deploy path.** That decision is an explicit operator gate. Until the operator chooses container / worker-port / merged-into-finance, ChittyBooks stays as repo-only — a candidate UI/workflow surface, not a runtime.
+
+Proof from repo files for the fake-domain retirement (no inference):
 
 | Evidence | Source | What it proves |
 |---|---|---|
@@ -64,16 +66,16 @@ Proof from repo files (no inference):
 | Bookkeeping engine already complete in ChittyFinance | `CHITTYAPPS/chittyfinance/server/routes/{allocations,classification,reports,tax,portfolio,charges}.ts` | No engine gap requires a second service |
 | Per-tenant `tenantId NOT NULL` at schema | `database/system.schema.ts:103` | Multi-tenant boundary is in ChittyFinance, not in ChittyBooks |
 
-Options NOT chosen:
-- **Option A (Cloud Run container)** — would resurrect the Python skeleton against a duplicate of ChittyFinance's bookkeeping engine. Creates competing source of truth. Rejected.
-- **Option B (Worker rewrite)** — same competition problem plus weeks of rewrite work. Rejected.
+Options preserved for the operator (deploy gate — not decided here):
+- **Option A — Cloud Run container.** Matches existing `.replit` config. Justification gap: ChittyFinance already owns bookkeeping engine; risk of competing source of truth.
+- **Option B — Worker rewrite.** Same competition risk + significant rewrite cost.
+- **Option C — Merged UI surface served by ChittyFinance.** Lowest cost, no new runtime. Default if no operator decision is made.
 
-## Followup actions (require user approval before merge)
+## Followup actions (operator-gated, not auto-merged)
 
-1. `CHITTYAPPS/chittybooks/CHARTER.md` — change "Cloudflare Worker at chittybooks.chitty.cc" to "UI surface served by ChittyFinance. No standalone deploy."
-2. `CHITTYAPPS/chittybooks/CHITTY.md` — same correction.
-3. Archive `CHITTYAPPS/chittybooks` repo or convert to a `client/` package in `CHITTYAPPS/chittyfinance`. (Org-owner action.)
-4. Remove `CHITTYBOOKS_URL` env reference from `CHITTYOS/chittycommand` (see `docs/proposals/ch1tty-connector-revision.md`).
+1. Pick A/B/C above. Each requires explicit approval.
+2. Reconcile `CHITTYAPPS/chittybooks/CHARTER.md` and `CHITTY.md` once the choice is made (currently both claim a Worker at `chittybooks.chitty.cc`, which is false).
+3. Patch `CHITTYOS/chittycommand` so its `booksClient` does not call the dead `CHITTYBOOKS_URL` (see `docs/proposals/ch1tty-connector-revision.md`). This is the only auto-mergeable action in this branch.
 
 ## Deploy gates
 

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -1,0 +1,66 @@
+# ChittyBooks ↔ ChittyFinance Contract
+
+> Engine / UI boundary. Not canon yet — proposal for the pentad.
+
+## Status (verified 2026-05-27)
+
+| Surface | Repo | Deploy | Health |
+|---|---|---|---|
+| ChittyFinance (engine) | `CHITTYAPPS/chittyfinance` | Hono on CF Workers at `finance.chitty.cc` | `200 ok` |
+| ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `chittybooks.chitty.cc` and `books.chitty.cc` do not resolve. |
+| ChittyLedger (substrate) | `CHITTYFOUNDATION/chittyledger` | Worker at `ledger.chitty.cc` | `200 ok` |
+| ChittyLedger (legacy fork) | `CHITTYOS/chittybooks` | Express + React, in-memory, not deployed | n/a — DUPLICATE, candidate for retirement or repurpose as ChittyLedger-Evidence seed |
+
+`CHITTYAPPS/chittybooks/CHARTER.md` claims a Cloudflare Worker at `chittybooks.chitty.cc`. The repository is a Python Flask application with `deploymentTarget = "cloudrun"`. Charter and code disagree.
+
+## Boundary
+
+- **ChittyFinance is the finance engine.** It owns: tenants, properties, accounts, transactions, allocations, classification (COA L0–L4), reports, valuation, AI summarization, OAuth connectors (Wave, Stripe, Google, Mercury via proxy), and webhooks. It writes evidence-grade entries to ChittyLedger.
+- **ChittyBooks is a bookkeeping UI/app.** It does **not** own bookkeeping records. It is a thin surface that reads ChittyFinance and (where applicable) ChittyLedger-Finance projections.
+- **ChittyLedger is the substrate.** ChittyLedger-Finance and ChittyLedger-Evidence are projections of it. See `docs/chittyledger-finance-design.md` for the canonical projection design.
+
+## Source of Truth (no competing writers)
+
+| Resource | Writer | Reader |
+|---|---|---|
+| `tenants`, `properties`, `accounts`, `transactions`, `allocations`, `classifications` | ChittyFinance | ChittyBooks (read-only), ChittyCommand, exports |
+| `financial_documents`, `financial_facts`, `reconciliation_conflicts` | ChittyLedger-Finance (via ChittyTrace ingest) | ChittyFinance, ChittyBooks |
+| Mercury/Wave/Stripe/Plaid raw events | external | ChittyFinance webhooks |
+
+ChittyBooks MUST NOT write transactions, allocations, or COA classifications directly. All mutations route to ChittyFinance.
+
+## API Surface ChittyBooks consumes
+
+All paths are under `https://finance.chitty.cc`. Auth: ChittyAuth Bearer token. Tenant: `X-Tenant-ID` header (server-side enforces from JWT claims; path param is not trusted).
+
+| Path (verified mounted) | Purpose for ChittyBooks |
+|---|---|
+| `/api/tenants` | List tenants the caller can read |
+| `/api/properties` | Property list |
+| `/api/accounts` | Account list + balances |
+| `/api/transactions` | Transaction feed (filter by date, account, tenant) |
+| `/api/allocations` | Allocation rules + history |
+| `/api/classification` | COA assignments + audit trail |
+| `/api/reports/*` | Pre-aggregated bookkeeping views |
+| `/api/integrations/status` | Which connectors are configured |
+| `/api/v1/documentation` | OpenAPI 3.0 spec (note: only the docs route is under `/api/v1`; data routes are under `/api`. See `docs/proposals/api-v1-prefix-fix.md`.) |
+
+## ChittyLedger projection paths (read-only)
+
+ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` aggregator endpoints — it does not query ChittyLedger directly. This preserves the substrate boundary: ChittyLedger does not know about ChittyBooks.
+
+## Deploy decision
+
+Three options were considered. Recommendation: **Option C** — retire `chittybooks.chitty.cc` as a separate deployable; keep ChittyBooks as a UI app served from a subpath under ChittyFinance (`finance.chitty.cc/books`) or as a static SPA pointing at the ChittyFinance API. Rationale:
+
+1. ChittyFinance already has the full bookkeeping surface (allocations, classification, COA L0-L4, reports, tax).
+2. ChittyBooks repo is a stale Python skeleton (last meaningful update 2026-03-28, surface ≈ 43KB `main.py`). Rewriting as a Worker is unjustified.
+3. "ChittyBooks as bookkeeping UI/app" (not engine) is the canonical position.
+
+Option A (Cloud Run container) and Option B (Worker rewrite) remain technically possible but require justification ChittyBooks does not currently have.
+
+## Deploy gates
+
+- [ ] PR approval before any `chittybooks.chitty.cc` DNS or Worker creation.
+- [ ] CHARTER.md in `CHITTYAPPS/chittybooks` must be reconciled with whichever option is chosen (currently aspirational).
+- [ ] `CHITTYOS/chittybooks` legacy fork is renamed, archived, or repurposed as ChittyLedger-Evidence — do not let it shadow the canonical surface.

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -24,7 +24,7 @@
 | Resource | Writer | Reader |
 |---|---|---|
 | `tenants`, `properties`, `accounts`, `transactions`, `allocations`, `classifications` | ChittyFinance | ChittyBooks (read-only), ChittyCommand, exports |
-| `financial_documents`, `financial_facts`, `reconciliation_conflicts` | ChittyLedger-Finance (via ChittyTrace ingest) | ChittyFinance, ChittyBooks |
+| `financial_documents`, `financial_facts`, `reconciliation_conflicts` | ChittyFinance writes into the ChittyLedger-Finance projection via `POST https://ledger.chitty.cc/api/entries` (matches `CHITTY.md` and `docs/proposals/chittyledger-naming-plan.md`). ChittyTrace ingest is an upstream feeder that hands material to ChittyFinance — it is not a second writer to the projection. | ChittyFinance, ChittyBooks |
 | Mercury/Wave/Stripe/Plaid raw events | external | ChittyFinance webhooks |
 
 ChittyBooks MUST NOT write transactions, allocations, or COA classifications directly. All mutations route to ChittyFinance.

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -7,7 +7,7 @@
 | Surface | Repo | Deploy | Health |
 |---|---|---|---|
 | ChittyFinance (engine) | `CHITTYAPPS/chittyfinance` | Hono on CF Workers at `finance.chitty.cc` | `200 ok` |
-| ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `books.chitty.cc` and `books.chitty.cc` do not resolve. |
+| ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `books.chitty.cc` does not resolve. |
 | ChittyLedger (substrate) | `CHITTYFOUNDATION/chittyledger` | Worker at `ledger.chitty.cc` | `200 ok` |
 | ChittyLedger (legacy fork) | `CHITTYOS/chittybooks` | Express + React, in-memory, not deployed | n/a — DUPLICATE, candidate for retirement or repurpose as ChittyLedger-Evidence seed |
 
@@ -62,7 +62,7 @@ Proof from repo files for the fake-domain retirement (no inference):
 | Repo is Python Flask, not Worker | `CHITTYAPPS/chittybooks/main.py` (43 KB), `Dockerfile`, `pyproject.toml`, `wsgi.py` | Charter ↔ code mismatch |
 | Replit config targets Cloud Run, not CF | `CHITTYAPPS/chittybooks/.replit` lines `deploymentTarget = "cloudrun"` and `[[ports]] localPort = 5000 externalPort = 80` | Never built as a Worker |
 | No `wrangler.toml`/`wrangler.jsonc` in repo | `find CHITTYAPPS/chittybooks -maxdepth 2 -name 'wrangler*'` returns empty | No CF deploy path exists |
-| No DNS for the claimed domain | `dig books.chitty.cc` and `dig books.chitty.cc` → NXDOMAIN (verified via `curl: Could not resolve host`) | Charter URL is aspirational |
+| No DNS for the claimed domain | `dig books.chitty.cc` → NXDOMAIN (verified via `curl: Could not resolve host`) | Charter URL is aspirational |
 | Bookkeeping engine already complete in ChittyFinance | `CHITTYAPPS/chittyfinance/server/routes/{allocations,classification,reports,tax,portfolio,charges}.ts` | No engine gap requires a second service |
 | Per-tenant `tenantId NOT NULL` at schema | `database/system.schema.ts:103` | Multi-tenant boundary is in ChittyFinance, not in ChittyBooks |
 

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -49,15 +49,31 @@ All paths are under `https://finance.chitty.cc`. Auth: ChittyAuth Bearer token. 
 
 ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` aggregator endpoints — it does not query ChittyLedger directly. This preserves the substrate boundary: ChittyLedger does not know about ChittyBooks.
 
-## Deploy decision
+## Deploy decision (DECISION, 2026-05-27)
 
-Three options were considered. Recommendation: **Option C** — retire `chittybooks.chitty.cc` as a separate deployable; keep ChittyBooks as a UI app served from a subpath under ChittyFinance (`finance.chitty.cc/books`) or as a static SPA pointing at the ChittyFinance API. Rationale:
+**Chosen: retire `chittybooks.chitty.cc` as a separate deployable. ChittyBooks becomes a UI surface served by ChittyFinance.**
 
-1. ChittyFinance already has the full bookkeeping surface (allocations, classification, COA L0-L4, reports, tax).
-2. ChittyBooks repo is a stale Python skeleton (last meaningful update 2026-03-28, surface ≈ 43KB `main.py`). Rewriting as a Worker is unjustified.
-3. "ChittyBooks as bookkeeping UI/app" (not engine) is the canonical position.
+Proof from repo files (no inference):
 
-Option A (Cloud Run container) and Option B (Worker rewrite) remain technically possible but require justification ChittyBooks does not currently have.
+| Evidence | Source | What it proves |
+|---|---|---|
+| Repo is Python Flask, not Worker | `CHITTYAPPS/chittybooks/main.py` (43 KB), `Dockerfile`, `pyproject.toml`, `wsgi.py` | Charter ↔ code mismatch |
+| Replit config targets Cloud Run, not CF | `CHITTYAPPS/chittybooks/.replit` lines `deploymentTarget = "cloudrun"` and `[[ports]] localPort = 5000 externalPort = 80` | Never built as a Worker |
+| No `wrangler.toml`/`wrangler.jsonc` in repo | `find CHITTYAPPS/chittybooks -maxdepth 2 -name 'wrangler*'` returns empty | No CF deploy path exists |
+| No DNS for the claimed domain | `dig chittybooks.chitty.cc` and `dig books.chitty.cc` → NXDOMAIN (verified via `curl: Could not resolve host`) | Charter URL is aspirational |
+| Bookkeeping engine already complete in ChittyFinance | `CHITTYAPPS/chittyfinance/server/routes/{allocations,classification,reports,tax,portfolio,charges}.ts` | No engine gap requires a second service |
+| Per-tenant `tenantId NOT NULL` at schema | `database/system.schema.ts:103` | Multi-tenant boundary is in ChittyFinance, not in ChittyBooks |
+
+Options NOT chosen:
+- **Option A (Cloud Run container)** — would resurrect the Python skeleton against a duplicate of ChittyFinance's bookkeeping engine. Creates competing source of truth. Rejected.
+- **Option B (Worker rewrite)** — same competition problem plus weeks of rewrite work. Rejected.
+
+## Followup actions (require user approval before merge)
+
+1. `CHITTYAPPS/chittybooks/CHARTER.md` — change "Cloudflare Worker at chittybooks.chitty.cc" to "UI surface served by ChittyFinance. No standalone deploy."
+2. `CHITTYAPPS/chittybooks/CHITTY.md` — same correction.
+3. Archive `CHITTYAPPS/chittybooks` repo or convert to a `client/` package in `CHITTYAPPS/chittyfinance`. (Org-owner action.)
+4. Remove `CHITTYBOOKS_URL` env reference from `CHITTYOS/chittycommand` (see `docs/proposals/ch1tty-connector-revision.md`).
 
 ## Deploy gates
 

--- a/docs/contracts/chittybooks-chittyfinance.md
+++ b/docs/contracts/chittybooks-chittyfinance.md
@@ -7,11 +7,11 @@
 | Surface | Repo | Deploy | Health |
 |---|---|---|---|
 | ChittyFinance (engine) | `CHITTYAPPS/chittyfinance` | Hono on CF Workers at `finance.chitty.cc` | `200 ok` |
-| ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `chittybooks.chitty.cc` and `books.chitty.cc` do not resolve. |
+| ChittyBooks (UI/app) | `CHITTYAPPS/chittybooks` | Python Flask, `main.py`, Dockerfile, `.replit` → `cloudrun` | **Not deployed**. `books.chitty.cc` and `books.chitty.cc` do not resolve. |
 | ChittyLedger (substrate) | `CHITTYFOUNDATION/chittyledger` | Worker at `ledger.chitty.cc` | `200 ok` |
 | ChittyLedger (legacy fork) | `CHITTYOS/chittybooks` | Express + React, in-memory, not deployed | n/a — DUPLICATE, candidate for retirement or repurpose as ChittyLedger-Evidence seed |
 
-`CHITTYAPPS/chittybooks/CHARTER.md` claims a Cloudflare Worker at `chittybooks.chitty.cc`. The repository is a Python Flask application with `deploymentTarget = "cloudrun"`. Charter and code disagree.
+`CHITTYAPPS/chittybooks/CHARTER.md` claims a Cloudflare Worker at `books.chitty.cc`. The repository is a Python Flask application with `deploymentTarget = "cloudrun"`. Charter and code disagree.
 
 ## Boundary
 
@@ -51,7 +51,7 @@ ChittyBooks reads ChittyLedger-Finance projection tables via `ChittyFinance` agg
 
 ## Deploy decision (2026-05-27)
 
-**Retired: the assumption that `chittybooks.chitty.cc` is a live API.** The domain does not resolve and no Worker exists. Code paths that target it MUST be disabled or guarded (see `docs/proposals/ch1tty-connector-revision.md`).
+**Retired: the assumption that `books.chitty.cc` is a live API.** The domain does not resolve and no Worker exists. Code paths that target it MUST be disabled or guarded (see `docs/proposals/ch1tty-connector-revision.md`).
 
 **Not yet decided: the actual ChittyBooks deploy path.** That decision is an explicit operator gate. Until the operator chooses container / worker-port / merged-into-finance, ChittyBooks stays as repo-only — a candidate UI/workflow surface, not a runtime.
 
@@ -62,7 +62,7 @@ Proof from repo files for the fake-domain retirement (no inference):
 | Repo is Python Flask, not Worker | `CHITTYAPPS/chittybooks/main.py` (43 KB), `Dockerfile`, `pyproject.toml`, `wsgi.py` | Charter ↔ code mismatch |
 | Replit config targets Cloud Run, not CF | `CHITTYAPPS/chittybooks/.replit` lines `deploymentTarget = "cloudrun"` and `[[ports]] localPort = 5000 externalPort = 80` | Never built as a Worker |
 | No `wrangler.toml`/`wrangler.jsonc` in repo | `find CHITTYAPPS/chittybooks -maxdepth 2 -name 'wrangler*'` returns empty | No CF deploy path exists |
-| No DNS for the claimed domain | `dig chittybooks.chitty.cc` and `dig books.chitty.cc` → NXDOMAIN (verified via `curl: Could not resolve host`) | Charter URL is aspirational |
+| No DNS for the claimed domain | `dig books.chitty.cc` and `dig books.chitty.cc` → NXDOMAIN (verified via `curl: Could not resolve host`) | Charter URL is aspirational |
 | Bookkeeping engine already complete in ChittyFinance | `CHITTYAPPS/chittyfinance/server/routes/{allocations,classification,reports,tax,portfolio,charges}.ts` | No engine gap requires a second service |
 | Per-tenant `tenantId NOT NULL` at schema | `database/system.schema.ts:103` | Multi-tenant boundary is in ChittyFinance, not in ChittyBooks |
 
@@ -74,11 +74,11 @@ Options preserved for the operator (deploy gate — not decided here):
 ## Followup actions (operator-gated, not auto-merged)
 
 1. Pick A/B/C above. Each requires explicit approval.
-2. Reconcile `CHITTYAPPS/chittybooks/CHARTER.md` and `CHITTY.md` once the choice is made (currently both claim a Worker at `chittybooks.chitty.cc`, which is false).
+2. Reconcile `CHITTYAPPS/chittybooks/CHARTER.md` and `CHITTY.md` once the choice is made (currently both claim a Worker at `books.chitty.cc`, which is false).
 3. Patch `CHITTYOS/chittycommand` so its `booksClient` does not call the dead `CHITTYBOOKS_URL` (see `docs/proposals/ch1tty-connector-revision.md`). This is the only auto-mergeable action in this branch.
 
 ## Deploy gates
 
-- [ ] PR approval before any `chittybooks.chitty.cc` DNS or Worker creation.
+- [ ] PR approval before any `books.chitty.cc` DNS or Worker creation.
 - [ ] CHARTER.md in `CHITTYAPPS/chittybooks` must be reconciled with whichever option is chosen (currently aspirational).
 - [ ] `CHITTYOS/chittybooks` legacy fork is renamed, archived, or repurposed as ChittyLedger-Evidence — do not let it shadow the canonical surface.

--- a/docs/contracts/mercury-multitenant.md
+++ b/docs/contracts/mercury-multitenant.md
@@ -51,8 +51,20 @@ Conflicts surface as `reconciliation_conflicts` in ChittyLedger-Finance (see `do
 - ChittyBooks may **not** create Wave invoices/sales directly — those route through ChittyFinance.
 - Credential rotation is owned by ChittyConnect concierge. ChittyBooks never sees a Mercury or Wave token.
 
+## Adversarial findings (2026-05-27 verification)
+
+**CRITICAL — schema gap.** `legal_person_chittyid` column is **NOT present** on `accounts` in `database/system.schema.ts` (verified at lines 101-103; only `id`, `tenantId`, and downstream columns exist). The Legal Person binding is therefore not enforceable at the database level today. Two remediation paths:
+
+- **Path A (schema migration)** — add `legal_person_chittyid TEXT NOT NULL` to `accounts` with a backfill plan. Coordinated cutover required (no migrations in this repo per CLAUDE.md "Schema Changes"; `drizzle-kit push` is destructive).
+- **Path B (interim metadata)** — store the binding in `accounts.metadata->>'legal_person_chittyid'` until Path A is ready. Adds a runtime check at the storage layer.
+
+Until one of these lands, the Mercury multitenant contract is **partially enforced** (tenant_id yes, legal_person no). Reconciliation reports MUST flag this in their output until the gap closes.
+
+**Verified OK.** `tenant_id` is `NOT NULL` on `accounts`, `transactions`, `properties`, `integrations` (`database/system.schema.ts`), so any insert missing `tenantId` fails at the database. The 18 inserts in `server/storage/system.ts` rely on the caller's `data` containing `tenantId`; the schema constraint provides defense-in-depth. No write path can bypass it.
+
 ## Deploy gates
 
+- [ ] **BLOCKER**: `legal_person_chittyid` column or metadata interim must exist before reconciliation reports reference it. Until then, the column is contract-only.
 - [ ] `legal_person_chittyid` column present on `accounts` (verify in `database/system.schema.ts` before reconciliation reports go live).
 - [ ] Per-business Mercury webhook secret in place (already shipped — PR #113).
 - [ ] No code path can write a Mercury-derived row with `tenant_id = NULL`. Enforce at the SystemStorage layer, not at the route layer.

--- a/docs/contracts/mercury-multitenant.md
+++ b/docs/contracts/mercury-multitenant.md
@@ -6,12 +6,12 @@
 
 1. **`tenant_id` required on every Mercury-derived record.** No row, webhook event, or queue message lacks it. Cross-tenant reads are server-side blocked, not client-trusted.
 2. **Legal Person ChittyID binding required.** Every Mercury account maps to exactly one Legal Person (`P-Legal` entity), recorded as `legal_person_chittyid` on the account row. Account ↔ Legal Person is many-to-one (one LLC can have many accounts).
-3. **Wave business mapping required.** Each `(tenant_id, legal_person_chittyid)` pair has at most one Wave business; the mapping lives in `integration_account_links` (source = `wave`, target = `mercury`). Unmapped Mercury accounts produce reconciliation conflicts, not silent omission.
+3. **Wave business mapping required.** Each `(tenant_id, legal_person_chittyid)` pair has at most one Wave business. The intended persistence point is a `integration_account_links` table (source = `wave`, target = `mercury`) — **this table does not yet exist in `database/system.schema.ts`**, so the mapping is contract-only today. Interim implementations may store the link under `integrations.metadata` until the table lands via a coordinated schema cutover (see `CLAUDE.md` → "Schema Changes"). Unmapped Mercury accounts produce reconciliation conflicts once the surface is live, not silent omission.
 4. **ChittyBooks reconciles over Mercury + Wave + Stripe** by reading ChittyFinance's reconciliation views. ChittyBooks never reaches into Mercury directly.
 
 ## Identity model
 
-```
+```text
 Person (P-Legal, e.g. "IT CAN BE LLC")
    │  legal_person_chittyid
    └── Account (Mercury account #1, #2, ...)
@@ -29,19 +29,17 @@ Person (P-Legal, e.g. "IT CAN BE LLC")
 |---|---|---|
 | Mercury read API | `https://api.mercury.com/api/v1` (direct, OAuth tokens scoped per tenant) | Token issued per `(tenant_id, legal_person_chittyid)` via ChittyConnect |
 | Mercury write API | `mercury-proxy` on `chittyserv-dev` (IP-allowlisted by Mercury) | `X-Mercury-Token` per request; proxy is stateless re tenancy |
-| Mercury webhooks | `/api/webhooks/mercury` on `finance.chitty.cc` | Per-business HMAC secret, resolves to `tenant_id` + `legal_person_chittyid` before write |
+| Mercury webhooks | `POST /api/webhooks/mercury/:tenantId` on `finance.chitty.cc` (native Mercury receiver, per `server/books/webhooks.ts`; PR #113). Per-tenant HMAC secret keyed at `webhook:mercury:secret:<tenantId>` in KV. The legacy `POST /api/webhooks/mercury` path was the ChittyConnect-normalized shim and is not the native receiver. | `tenant_id` is the path param and is verified by HMAC; `legal_person_chittyid` resolution is **not** performed inside the webhook handler today — it joins downstream via the local account row. |
 
 The write proxy at `CHITTYOS/mercury-proxy` is **not** a tenant boundary — it is a network egress shim. Tenancy is enforced by the caller (ChittyFinance) before reaching it.
 
 ## Reconciliation surface
 
-ChittyBooks consumes these ChittyFinance endpoints, not raw Mercury:
+ChittyBooks consumes these ChittyFinance endpoints, not raw Mercury. **Endpoints marked _(proposed)_ are not yet mounted** — they are the target surface for the reconciliation contract and must ship before ChittyBooks relies on them:
 
-- `GET /api/transactions?source=mercury` — Mercury txns scoped to caller's tenant
-- `GET /api/transactions?source=wave` — Wave txns scoped to caller's tenant
-- `GET /api/transactions?source=stripe` — Stripe charges scoped to caller's tenant
-- `GET /api/reports/reconciliation?tenant_id=...&period=...` — three-way diff (Mercury ↔ Wave ↔ Stripe)
-- `GET /api/integrations/status` — per-source connection health + last-sync timestamps
+- `GET /api/transactions` — tenant-scoped transaction feed. Today the handler accepts only `?limit=`; `?source=mercury|wave|stripe` filtering is _(proposed)_ and must be added to `server/books/transactions.ts` before this contract is satisfied.
+- `GET /api/reports/reconciliation?tenant_id=...&period=...` _(proposed)_ — three-way diff (Mercury ↔ Wave ↔ Stripe). Not mounted; only `/api/reports/consolidated` exists today.
+- `GET /api/integrations/status` — currently returns per-provider `configured` booleans from env vars (see `server/routes/integrations.ts`). Last-sync timestamps and per-source health _(proposed)_ require extending the handler to read sync state.
 
 Conflicts surface as `reconciliation_conflicts` in ChittyLedger-Finance (see `docs/chittyledger-finance-design.md`).
 

--- a/docs/contracts/mercury-multitenant.md
+++ b/docs/contracts/mercury-multitenant.md
@@ -1,0 +1,58 @@
+# Mercury Multitenant Model
+
+> How Mercury bank data flows through ChittyFinance with tenant + Legal Person isolation.
+
+## Requirements (non-negotiable)
+
+1. **`tenant_id` required on every Mercury-derived record.** No row, webhook event, or queue message lacks it. Cross-tenant reads are server-side blocked, not client-trusted.
+2. **Legal Person ChittyID binding required.** Every Mercury account maps to exactly one Legal Person (`P-Legal` entity), recorded as `legal_person_chittyid` on the account row. Account ↔ Legal Person is many-to-one (one LLC can have many accounts).
+3. **Wave business mapping required.** Each `(tenant_id, legal_person_chittyid)` pair has at most one Wave business; the mapping lives in `integration_account_links` (source = `wave`, target = `mercury`). Unmapped Mercury accounts produce reconciliation conflicts, not silent omission.
+4. **ChittyBooks reconciles over Mercury + Wave + Stripe** by reading ChittyFinance's reconciliation views. ChittyBooks never reaches into Mercury directly.
+
+## Identity model
+
+```
+Person (P-Legal, e.g. "IT CAN BE LLC")
+   │  legal_person_chittyid
+   └── Account (Mercury account #1, #2, ...)
+          │  tenant_id
+          └── Transaction (mercury txn rows)
+                 │  metadata.mercury_kind, mercury_id
+                 └── Allocation → Property/Lease (Business surface)
+```
+
+- **Business / Legalink separation**: business operations (property, lease, allocation) live on the Business surface; the Legal Person binding lives on the Authority/Person surface. They join through `legal_person_chittyid`, not by sharing schemas.
+
+## Data sources
+
+| Source | Path | Tenant binding |
+|---|---|---|
+| Mercury read API | `https://api.mercury.com/api/v1` (direct, OAuth tokens scoped per tenant) | Token issued per `(tenant_id, legal_person_chittyid)` via ChittyConnect |
+| Mercury write API | `mercury-proxy` on `chittyserv-dev` (IP-allowlisted by Mercury) | `X-Mercury-Token` per request; proxy is stateless re tenancy |
+| Mercury webhooks | `/api/webhooks/mercury` on `finance.chitty.cc` | Per-business HMAC secret, resolves to `tenant_id` + `legal_person_chittyid` before write |
+
+The write proxy at `CHITTYOS/mercury-proxy` is **not** a tenant boundary — it is a network egress shim. Tenancy is enforced by the caller (ChittyFinance) before reaching it.
+
+## Reconciliation surface
+
+ChittyBooks consumes these ChittyFinance endpoints, not raw Mercury:
+
+- `GET /api/transactions?source=mercury` — Mercury txns scoped to caller's tenant
+- `GET /api/transactions?source=wave` — Wave txns scoped to caller's tenant
+- `GET /api/transactions?source=stripe` — Stripe charges scoped to caller's tenant
+- `GET /api/reports/reconciliation?tenant_id=...&period=...` — three-way diff (Mercury ↔ Wave ↔ Stripe)
+- `GET /api/integrations/status` — per-source connection health + last-sync timestamps
+
+Conflicts surface as `reconciliation_conflicts` in ChittyLedger-Finance (see `docs/chittyledger-finance-design.md`).
+
+## What is explicitly out of scope
+
+- ChittyBooks may **not** call Mercury directly.
+- ChittyBooks may **not** create Wave invoices/sales directly — those route through ChittyFinance.
+- Credential rotation is owned by ChittyConnect concierge. ChittyBooks never sees a Mercury or Wave token.
+
+## Deploy gates
+
+- [ ] `legal_person_chittyid` column present on `accounts` (verify in `database/system.schema.ts` before reconciliation reports go live).
+- [ ] Per-business Mercury webhook secret in place (already shipped — PR #113).
+- [ ] No code path can write a Mercury-derived row with `tenant_id = NULL`. Enforce at the SystemStorage layer, not at the route layer.

--- a/docs/proposals/api-v1-prefix-fix.md
+++ b/docs/proposals/api-v1-prefix-fix.md
@@ -1,0 +1,40 @@
+# API path prefix: docs say `/api/v1`, code mounts `/api` — fix proposal
+
+## Symptom
+
+`https://finance.chitty.cc/api/v1/entities` → `404`.
+`https://finance.chitty.cc/api/accounts` → `401` (auth working as designed).
+`https://finance.chitty.cc/api/v1/documentation` → `200` (OpenAPI spec).
+
+CLAUDE.md and CHARTER.md advertise `/api/v1/*`. Only the OpenAPI spec route uses `/api/v1`. All data routes are mounted at `/api/*`.
+
+## Evidence
+
+- `server/app.ts:74-118` — every `app.route('/', xxxRoutes)`. Each route module defines `/api/<resource>` internally (no `/v1` segment).
+- `server/routes/docs.ts:7` — `docRoutes.get('/api/v1/documentation', ...)` — only route under `/api/v1`.
+- Probe: 8/8 `/api/v1/*` data paths return 404; the 8 `/api/*` data paths return 401 (auth required, route exists).
+
+## Two fixes, choose one
+
+### Option 1 — Fix the docs (recommended, zero risk)
+
+- Change `CLAUDE.md` and any service consumers (notably `CHITTYOS/chittycommand/src/lib/integrations.ts:230` `financeClient`) to point at `/api/*`, not `/api/v1/*`.
+- Keep `/api/v1/documentation` as-is (it is the OpenAPI alias, harmless).
+- Update OpenAPI `servers[0].url` if downstream tooling expects `/api/v1` — it currently emits `https://finance.chitty.cc` with paths starting `/api/`, which is consistent. **Verify before committing.**
+- Estimated diff: 1 markdown line per consumer + audit.
+
+### Option 2 — Rename routes to `/api/v1/*` (breaking)
+
+- Add `const apiV1 = new Hono().basePath('/api/v1');` and remount under it.
+- Touches every route file (~30 files).
+- Breaks every existing consumer simultaneously. Requires coordinated cutover with ChittyCommand, ChittyBooks (when it ships), and any external integrators.
+- Estimated diff: ~30 files + migration plan.
+
+## Recommendation
+
+Option 1. There is no benefit to `/v1` versioning until a v2 is on the horizon, and we are not designing one. The current `/api/<resource>` shape is already the de facto contract.
+
+## Deploy gate
+
+- [ ] Approval before any route remount.
+- [ ] If Option 1: search every CHITTYOS/CHITTYFOUNDATION/CHITTYAPPS repo for `finance.chitty.cc/api/v1` and confirm zero consumers depend on it. Verified consumers today: ChittyCommand uses `financeClient` — must check path it calls.

--- a/docs/proposals/api-v1-prefix-fix.md
+++ b/docs/proposals/api-v1-prefix-fix.md
@@ -1,40 +1,32 @@
-# API path prefix: docs say `/api/v1`, code mounts `/api` — fix proposal
+# API path prefix — RESOLVED as non-issue
 
-## Symptom
+## Original report
 
-`https://finance.chitty.cc/api/v1/entities` → `404`.
-`https://finance.chitty.cc/api/accounts` → `401` (auth working as designed).
-`https://finance.chitty.cc/api/v1/documentation` → `200` (OpenAPI spec).
+> `https://finance.chitty.cc/api/v1/entities` → `404`. Docs imply `/api/v1/*` everywhere.
 
-CLAUDE.md and CHARTER.md advertise `/api/v1/*`. Only the OpenAPI spec route uses `/api/v1`. All data routes are mounted at `/api/*`.
+## Investigation (2026-05-27)
 
-## Evidence
+Two route families exist by design:
 
-- `server/app.ts:74-118` — every `app.route('/', xxxRoutes)`. Each route module defines `/api/<resource>` internally (no `/v1` segment).
-- `server/routes/docs.ts:7` — `docRoutes.get('/api/v1/documentation', ...)` — only route under `/api/v1`.
-- Probe: 8/8 `/api/v1/*` data paths return 404; the 8 `/api/*` data paths return 401 (auth required, route exists).
+| Family | Mount | Examples | Verified |
+|---|---|---|---|
+| **Operational/meta** | `/api/v1/*` | `/api/v1/status`, `/api/v1/metrics`, `/api/v1/documentation` | `server/routes/health.ts:21,38`; `server/routes/docs.ts:7`. All return `200`. |
+| **Resource data** | `/api/*` | `/api/accounts`, `/api/transactions`, `/api/properties`, `/api/tenants`, `/api/integrations/*`, `/api/reports/*`, etc. | `server/app.ts:74-118`; each route module under `server/routes/`. All return `401` (auth) — routes exist. |
 
-## Two fixes, choose one
+`/api/v1/entities` returns `404` because **there is no `entities` resource**, not because of a path mismatch. The original concern came from assuming the `/api/v1` prefix applied to data routes; it does not.
 
-### Option 1 — Fix the docs (recommended, zero risk)
+## Decision: no code change
 
-- Change `CLAUDE.md` and any service consumers (notably `CHITTYOS/chittycommand/src/lib/integrations.ts:230` `financeClient`) to point at `/api/*`, not `/api/v1/*`.
-- Keep `/api/v1/documentation` as-is (it is the OpenAPI alias, harmless).
-- Update OpenAPI `servers[0].url` if downstream tooling expects `/api/v1` — it currently emits `https://finance.chitty.cc` with paths starting `/api/`, which is consistent. **Verify before committing.**
-- Estimated diff: 1 markdown line per consumer + audit.
+- The split (meta under `/v1`, resources unprefixed) is intentional and consistent with the OpenAPI spec at `/api/v1/documentation` which lists `paths` correctly.
+- All 5 in-repo references to `/api/v1` (`.github/workflows/register.yml`, `deploy/registration/chittyfinance.registration.json`, `client/src/pages/Landing.tsx:342`, `.claude/commands/quick-deploy.md:28`, plans) point at real endpoints. **Nothing to fix.**
+- All 2 cross-org consumer references (`chittycommand/src/lib/integrations.ts:249`, `chittyregistry/src/routes/notion-webhooks.ts`) target `/api/<resource>` — correct.
 
-### Option 2 — Rename routes to `/api/v1/*` (breaking)
+## Documentation patch (the only action)
 
-- Add `const apiV1 = new Hono().basePath('/api/v1');` and remount under it.
-- Touches every route file (~30 files).
-- Breaks every existing consumer simultaneously. Requires coordinated cutover with ChittyCommand, ChittyBooks (when it ships), and any external integrators.
-- Estimated diff: ~30 files + migration plan.
+Add a single sentence to `CLAUDE.md` under "Where Things Live" → routes section:
 
-## Recommendation
+> Resource routes are mounted at `/api/<resource>` (no `/v1` prefix). Only operational/meta routes (`status`, `metrics`, `documentation`) live under `/api/v1/`. The OpenAPI spec at `/api/v1/documentation` is authoritative.
 
-Option 1. There is no benefit to `/v1` versioning until a v2 is on the horizon, and we are not designing one. The current `/api/<resource>` shape is already the de facto contract.
+## Deploy gates
 
-## Deploy gate
-
-- [ ] Approval before any route remount.
-- [ ] If Option 1: search every CHITTYOS/CHITTYFOUNDATION/CHITTYAPPS repo for `finance.chitty.cc/api/v1` and confirm zero consumers depend on it. Verified consumers today: ChittyCommand uses `financeClient` — must check path it calls.
+- None. No routing or worker change.

--- a/docs/proposals/ch1tty-connector-revision.md
+++ b/docs/proposals/ch1tty-connector-revision.md
@@ -14,7 +14,7 @@
 
 | Concern | Existing real service | Path |
 |---|---|---|
-| Mercury read | Direct Mercury API per-tenant token | `https://api.mercury.com/api/v1` via `mercuryClient(token)` in `chittycommand/src/lib/integrations.ts:551` |
+| Mercury read | Via ChittyConnect (canonical path) — ChittyFinance's own Mercury account reader (`server/routes/mercury.ts`) goes through ChittyConnect, and `chittyagent-connect` is defined as the Mercury Bank proxy for every bank API call. ChittyCommand reads should follow the same path; direct `api.mercury.com` calls are reserved for narrow service-internal uses behind the ChittyConnect credential boundary. | ChittyConnect → Mercury (preferred); fall back to `mercuryClient(token)` in `chittycommand/src/lib/integrations.ts:551` only when ChittyConnect is unavailable. |
 | Mercury write | mercury-proxy on chittyserv-dev | `https://mercury-proxy.chitty.cc` (CF tunnel) — POST `/proxy` with `X-Mercury-Token` |
 | Mercury webhooks | ChittyFinance | `POST https://finance.chitty.cc/api/webhooks/mercury` (PR #113, per-business HMAC secrets) |
 | Bookkeeping reads | ChittyFinance | `GET https://finance.chitty.cc/api/transactions` and `/api/reports/*` |

--- a/docs/proposals/ch1tty-connector-revision.md
+++ b/docs/proposals/ch1tty-connector-revision.md
@@ -6,7 +6,7 @@
 
 | Reference | Location | Status today | Action |
 |---|---|---|---|
-| `CHITTYBOOKS_URL = "https://chittybooks.chitty.cc"` | `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:168` | DNS does not resolve | **Disable behind deploy gate** until ChittyBooks deploy decision lands (see `docs/contracts/chittybooks-chittyfinance.md`). |
+| `CHITTYBOOKS_URL = "https://books.chitty.cc"` | `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:168` | DNS does not resolve | **Disable behind deploy gate** until ChittyBooks deploy decision lands (see `docs/contracts/chittybooks-chittyfinance.md`). |
 | `booksClient(env)` | `chittycommand/src/lib/integrations.ts:618` | Implemented; target URL does not resolve | Wrap in env guard: if `CHITTYBOOKS_URL` is unset or `*.chitty.cc` DNS-lookup fails on cold-start, return `null` like `financeClient` does on missing config. Add log line `[books] disabled — no CHITTYBOOKS_URL`. |
 | Service-list expectation that `chittybooks` is in registry response | `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:934` | Registry will not return chittybooks because nothing is registered | Remove `chittybooks` from the "expected services" assertion until it deploys. |
 
@@ -26,8 +26,8 @@
 
 Apply these to `CHITTYOS/chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md` in a follow-up PR on that repo:
 
-1. **Replace** `CHITTYBOOKS_URL = "https://chittybooks.chitty.cc"` with `CHITTYBOOKS_URL = ""` and add note: "ChittyBooks is a UI-layer surface, not a separate API. For bookkeeping reads/writes, target ChittyFinance (`https://finance.chitty.cc/api/*`)."
-2. **Mark `booksClient` deprecated** in `chittycommand/src/lib/integrations.ts` until/unless ChittyBooks deploys as its own service. Comment: `// @deprecated: chittybooks.chitty.cc does not resolve. Use financeClient for bookkeeping.`
+1. **Replace** `CHITTYBOOKS_URL = "https://books.chitty.cc"` with `CHITTYBOOKS_URL = ""` and add note: "ChittyBooks is a UI-layer surface, not a separate API. For bookkeeping reads/writes, target ChittyFinance (`https://finance.chitty.cc/api/*`)."
+2. **Mark `booksClient` deprecated** in `chittycommand/src/lib/integrations.ts` until/unless ChittyBooks deploys as its own service. Comment: `// @deprecated: books.chitty.cc does not resolve. Use financeClient for bookkeeping.`
 3. **Remove the registry-expectation assertion** for `chittybooks` (or change to "optional, present only if deployed").
 4. **Add deploy gate** at the top of the plan: "This plan assumes ChittyBooks is a deployed bookkeeping API. As of 2026-05-27 that is false. Do not implement task 3+ until the deploy decision in `chittyfinance/docs/contracts/chittybooks-chittyfinance.md` lands."
 

--- a/docs/proposals/ch1tty-connector-revision.md
+++ b/docs/proposals/ch1tty-connector-revision.md
@@ -1,0 +1,38 @@
+# ch1tty Mercury/ChittyBooks connector — revision
+
+> Revises the canonical draft `CHITTYOS/chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md` to route through real services or gate fake endpoints. Companion to the contracts in `docs/contracts/`.
+
+## Fake / dead endpoints in the current draft
+
+| Reference | Location | Status today | Action |
+|---|---|---|---|
+| `CHITTYBOOKS_URL = "https://chittybooks.chitty.cc"` | `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:168` | DNS does not resolve | **Disable behind deploy gate** until ChittyBooks deploy decision lands (see `docs/contracts/chittybooks-chittyfinance.md`). |
+| `booksClient(env)` | `chittycommand/src/lib/integrations.ts:618` | Implemented; target URL does not resolve | Wrap in env guard: if `CHITTYBOOKS_URL` is unset or `*.chitty.cc` DNS-lookup fails on cold-start, return `null` like `financeClient` does on missing config. Add log line `[books] disabled — no CHITTYBOOKS_URL`. |
+| Service-list expectation that `chittybooks` is in registry response | `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:934` | Registry will not return chittybooks because nothing is registered | Remove `chittybooks` from the "expected services" assertion until it deploys. |
+
+## Real services to route through (use these, not stubs)
+
+| Concern | Existing real service | Path |
+|---|---|---|
+| Mercury read | Direct Mercury API per-tenant token | `https://api.mercury.com/api/v1` via `mercuryClient(token)` in `chittycommand/src/lib/integrations.ts:551` |
+| Mercury write | mercury-proxy on chittyserv-dev | `https://mercury-proxy.chitty.cc` (CF tunnel) — POST `/proxy` with `X-Mercury-Token` |
+| Mercury webhooks | ChittyFinance | `POST https://finance.chitty.cc/api/webhooks/mercury` (PR #113, per-business HMAC secrets) |
+| Bookkeeping reads | ChittyFinance | `GET https://finance.chitty.cc/api/transactions` and `/api/reports/*` |
+| Bookkeeping writes | ChittyFinance | `POST https://finance.chitty.cc/api/transactions`, `/api/allocations`, `/api/classification` — **not** a separate `chittybooks` write API |
+| Credentials | ChittyConnect | `https://connect.chitty.cc` via concierge — never chat-paste |
+| Ledger writes | ChittyLedger | `https://ledger.chitty.cc/entries` (auth-required) |
+
+## Concrete revisions to the canonical plan
+
+Apply these to `CHITTYOS/chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md` in a follow-up PR on that repo:
+
+1. **Replace** `CHITTYBOOKS_URL = "https://chittybooks.chitty.cc"` with `CHITTYBOOKS_URL = ""` and add note: "ChittyBooks is a UI-layer surface, not a separate API. For bookkeeping reads/writes, target ChittyFinance (`https://finance.chitty.cc/api/*`)."
+2. **Mark `booksClient` deprecated** in `chittycommand/src/lib/integrations.ts` until/unless ChittyBooks deploys as its own service. Comment: `// @deprecated: chittybooks.chitty.cc does not resolve. Use financeClient for bookkeeping.`
+3. **Remove the registry-expectation assertion** for `chittybooks` (or change to "optional, present only if deployed").
+4. **Add deploy gate** at the top of the plan: "This plan assumes ChittyBooks is a deployed bookkeeping API. As of 2026-05-27 that is false. Do not implement task 3+ until the deploy decision in `chittyfinance/docs/contracts/chittybooks-chittyfinance.md` lands."
+
+## Deploy gates
+
+- [ ] PR against `CHITTYOS/chittycommand` to make `booksClient` lazy + null-returning when target is unset.
+- [ ] No new caller of `booksClient` lands until ChittyBooks deploy choice is made.
+- [ ] Mercury reads keep routing through `mercuryClient` (real); writes through `mercury-proxy` (real).

--- a/docs/proposals/ch1tty-connector-revision.md
+++ b/docs/proposals/ch1tty-connector-revision.md
@@ -20,7 +20,7 @@
 | Bookkeeping reads | ChittyFinance | `GET https://finance.chitty.cc/api/transactions` and `/api/reports/*` |
 | Bookkeeping writes | ChittyFinance | `POST https://finance.chitty.cc/api/transactions`, `/api/allocations`, `/api/classification` — **not** a separate `chittybooks` write API |
 | Credentials | ChittyConnect | `https://connect.chitty.cc` via concierge — never chat-paste |
-| Ledger writes | ChittyLedger | `https://ledger.chitty.cc/entries` (auth-required) |
+| Ledger writes | ChittyLedger | `POST https://ledger.chitty.cc/api/entries` (auth-required; matches ChittyFinance's `server/lib/ledger-client.ts` which posts to `${base}/api/entries`) |
 
 ## Concrete revisions to the canonical plan
 

--- a/docs/proposals/chittyledger-naming-plan.md
+++ b/docs/proposals/chittyledger-naming-plan.md
@@ -32,7 +32,7 @@ Projections are **views over the substrate**, not separate ledgers. They MUST NO
 2. **Archive** the renamed repo if no active work depends on it. Otherwise port its UI components into `CHITTYAPPS/chittyevidence` (which is the active evidence service).
 3. **Delete or vendor the nested `chittychronicle/chittyledger` and `chittyscore/chittyfinance`** — these are working-tree noise from prior submodule experiments. They are not canon.
 4. **Add a top-of-README disambiguation banner to `CHITTYFOUNDATION/chittyledger`**: "ChittyLedger is the substrate. ChittyLedger-Finance and ChittyLedger-Evidence are projections defined in their respective service repos; they are not separate deployables."
-5. **Add a `ChittyLedger-Finance` section to `CHITTYAPPS/chittyfinance/CHITTY.md`** that says: "ChittyFinance hosts the ChittyLedger-Finance projection. The schema is defined in `docs/chittyledger-finance-design.md`. The projection's writer is ChittyFinance; its substrate is `ledger.chitty.cc`."
+5. **Verify the `ChittyLedger-Finance` section in `CHITTYAPPS/chittyfinance/CHITTY.md`** (already present at CHITTY.md:109-114) still reads: "ChittyFinance hosts the ChittyLedger-Finance projection. The schema is defined in `docs/chittyledger-finance-design.md`. The projection's writer is ChittyFinance; its substrate is `ledger.chitty.cc`." Update only if drift is detected.
 6. **Canon URI alignment** — confirm `chittycanon://core/services/chitty-ledger` resolves to the substrate, not the legacy fork. Update ChittyRegister if it points at the wrong repo.
 
 ## Deploy gates

--- a/docs/proposals/chittyledger-naming-plan.md
+++ b/docs/proposals/chittyledger-naming-plan.md
@@ -13,14 +13,14 @@
 
 ## Target model
 
-```
+```text
 ChittyLedger (substrate)        — CHITTYFOUNDATION/chittyledger    — ledger.chitty.cc
 ├── ChittyLedger-Finance        — projection (tables in substrate DB; surface via ChittyFinance)
 │       schema doc:               docs/chittyledger-finance-design.md (already canon)
-│       writer:                   ChittyFinance via /entries
+│       writer:                   ChittyFinance via POST /api/entries
 │       reader:                   ChittyFinance, ChittyBooks (read-only via ChittyFinance aggregators)
 └── ChittyLedger-Evidence       — projection (tables in substrate DB; surface via ChittyEvidence)
-        writer:                   ChittyTrace + ChittyEvidence via /entries
+        writer:                   ChittyTrace + ChittyEvidence via POST /api/entries
         reader:                   ChittyCases, ChittyResolution
 ```
 

--- a/docs/proposals/chittyledger-naming-plan.md
+++ b/docs/proposals/chittyledger-naming-plan.md
@@ -1,0 +1,42 @@
+# ChittyLedger naming collision — substrate + projections plan
+
+> Resolves the `CHITTYFOUNDATION/chittyledger` vs `CHITTYOS/chittyledger` collision. Aligns with the substrate/projection model in `docs/chittyledger-finance-design.md`.
+
+## Current state (verified 2026-05-27)
+
+| Repo | Description | Deploy | Role |
+|---|---|---|---|
+| `CHITTYFOUNDATION/chittyledger` | Worker at `ledger.chitty.cc`. Has CHARTER/CHITTY/CLAUDE pentad. Endpoints: `POST /entries`, `GET /custody/:entityId`, `GET /verify`. | ✅ `200 ok` at `ledger.chitty.cc/health` | **Canonical substrate.** |
+| `CHITTYOS/chittyledger` | "ChittyChain Evidence Ledger" — Express + React + Drizzle, in-memory storage, evidence/legal UI. No deploy. Last touched 2026-03-25. | none | Legacy fork. Functionally an evidence UI app, not a ledger. |
+| `CHITTYOS/chittychronicle/chittyledger` | Nested submodule/copy. | n/a | Noise. |
+| `CHITTYFOUNDATION/chittyscore/chittyfinance` | Nested submodule/copy. | n/a | Noise. |
+
+## Target model
+
+```
+ChittyLedger (substrate)        — CHITTYFOUNDATION/chittyledger    — ledger.chitty.cc
+├── ChittyLedger-Finance        — projection (tables in substrate DB; surface via ChittyFinance)
+│       schema doc:               docs/chittyledger-finance-design.md (already canon)
+│       writer:                   ChittyFinance via /entries
+│       reader:                   ChittyFinance, ChittyBooks (read-only via ChittyFinance aggregators)
+└── ChittyLedger-Evidence       — projection (tables in substrate DB; surface via ChittyEvidence)
+        writer:                   ChittyTrace + ChittyEvidence via /entries
+        reader:                   ChittyCases, ChittyResolution
+```
+
+Projections are **views over the substrate**, not separate ledgers. They MUST NOT have separate hash chains.
+
+## Plan
+
+1. **Rename `CHITTYOS/chittyledger` → `CHITTYOS/chittyledger-evidence-legacy`** and add a top-of-README banner: "Legacy evidence-UI fork. Not the canonical ChittyLedger. See `CHITTYFOUNDATION/chittyledger` for the substrate." This preserves git history while removing the naming collision.
+2. **Archive** the renamed repo if no active work depends on it. Otherwise port its UI components into `CHITTYAPPS/chittyevidence` (which is the active evidence service).
+3. **Delete or vendor the nested `chittychronicle/chittyledger` and `chittyscore/chittyfinance`** — these are working-tree noise from prior submodule experiments. They are not canon.
+4. **Add a top-of-README disambiguation banner to `CHITTYFOUNDATION/chittyledger`**: "ChittyLedger is the substrate. ChittyLedger-Finance and ChittyLedger-Evidence are projections defined in their respective service repos; they are not separate deployables."
+5. **Add a `ChittyLedger-Finance` section to `CHITTYAPPS/chittyfinance/CHITTY.md`** that says: "ChittyFinance hosts the ChittyLedger-Finance projection. The schema is defined in `docs/chittyledger-finance-design.md`. The projection's writer is ChittyFinance; its substrate is `ledger.chitty.cc`."
+6. **Canon URI alignment** — confirm `chittycanon://core/services/chitty-ledger` resolves to the substrate, not the legacy fork. Update ChittyRegister if it points at the wrong repo.
+
+## Deploy gates
+
+- [ ] Repo rename requires org-owner approval (`gh repo rename` on CHITTYOS/chittyledger).
+- [ ] No DNS or Worker changes — `ledger.chitty.cc` stays where it is. This plan is paper-only.
+- [ ] Canon URI update in ChittyRegister needs schema-overlord review.


### PR DESCRIPTION
## Summary

Docs-only branch from /goal audit of finance/books/ledger surfaces. No code or runtime changes.

Five new docs:

- `docs/contracts/chittybooks-chittyfinance.md` — engine/UI boundary, source-of-truth table, API surface, deploy decision (retires the **fake `books.chitty.cc` live-API assumption** only; actual deploy choice stays an explicit operator gate)
- `docs/contracts/mercury-multitenant.md` — tenant_id + legal_person_chittyid + Wave mapping rules. **Flags critical schema gap**: `legal_person_chittyid` is not on `accounts` in `database/system.schema.ts`
- `docs/proposals/api-v1-prefix-fix.md` — resolves the `/api/v1/*` 404 as a non-issue (meta routes are intentionally under `/api/v1`, resource routes under `/api/<resource>`). One-sentence `CLAUDE.md` clarification only.
- `docs/proposals/ch1tty-connector-revision.md` — names the dead `CHITTYBOOKS_URL` endpoint in `chittycommand/docs/plans/2026-02-23-mercury-chittybooks-plan.md:168` and `chittycommand/src/lib/integrations.ts:618`; routes bookkeeping reads/writes through real `finance.chitty.cc` paths
- `docs/proposals/chittyledger-naming-plan.md` — substrate (FOUNDATION/chittyledger) + Finance/Evidence projections; plan to rename `CHITTYOS/chittyledger` → `-evidence-legacy`

## Validation

- All 5 markdown files parse (python3 read OK).
- ChittyCommand `financeClient` verified to call `/api/accounts` not `/api/v1/accounts` → docs-only path-prefix clarification has zero consumer breakage.
- OpenAPI spec at `/api/v1/documentation` enumerated: 9 paths, only `/health` and `/api/v1/{status,metrics,documentation}` under `/api/v1`; resource paths at `/api/*`.
- `SystemStorage` enforces tenancy via `tenant_id NOT NULL` schema column + 117 `tenantId` references.

## Followups (not in this PR)

- PR-2 (`CHITTYOS/chittycommand`): lazy-disable `booksClient` — PR-ready, awaiting owner approval
- ChittyBooks deploy choice (A container / B worker / C merged): explicit operator gate
- `CHITTYOS/chittyledger` rename: org-owner action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API routing: resource endpoints under /api/<resource>, operational/meta under /api/v1/ with OpenAPI at /api/v1/documentation
  * Added service boundaries and ownership contract for ChittyFinance, ChittyBooks, ChittyLedger (read-only projection, no competing writers)
  * Defined Mercury multitenant identity/isolation rules, schema gap and deploy gates (tenant enforcement, webhook/secret checks)
  * Updated connector guidance: CHITTYBOOKS_URL handling, lazy client behavior, and legacy ledger renaming/retire plans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->