### PR TITLE
feat(mercury): legal_person_chittyid Path B interim binding + reconciliation flag

### DIFF
--- a/server/__tests__/legal-person-binding.test.ts
+++ b/server/__tests__/legal-person-binding.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the Path B legal_person_chittyid binding helpers.
+ *
+ * Pure unit tests — no DB, no mocks. Exercises the real helper code that
+ * the Mercury webhook write path calls into.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isLegalPersonChittyId,
+  getLegalPersonChittyId,
+  setLegalPersonChittyId,
+  checkLegalPersonBinding,
+  LEGAL_PERSON_METADATA_KEY,
+} from '../lib/legal-person-binding';
+
+// Real-shaped ChittyIDs (VV-G-LLL-SSSS-T-YM-C-X). Type position is the 5th group.
+const LEGAL_PERSON_ID = 'US-1-LLC-A1B2-P-26-3-Z'; // T = P (Person), Legal subtype implied upstream
+const LOCATION_ID = 'US-1-LLC-A1B2-L-26-3-Z'; // T = L
+const THING_ID = 'US-1-LLC-A1B2-T-26-3-Z'; // T = T
+
+describe('isLegalPersonChittyId', () => {
+  it('accepts a well-formed P-type ChittyID', () => {
+    expect(isLegalPersonChittyId(LEGAL_PERSON_ID)).toBe(true);
+  });
+  it('rejects non-Person types (L, T, E, A)', () => {
+    expect(isLegalPersonChittyId(LOCATION_ID)).toBe(false);
+    expect(isLegalPersonChittyId(THING_ID)).toBe(false);
+  });
+  it('rejects malformed strings', () => {
+    expect(isLegalPersonChittyId('')).toBe(false);
+    expect(isLegalPersonChittyId('not-a-chittyid')).toBe(false);
+    expect(isLegalPersonChittyId('US-1-LLC-A1B2-P-26-3')).toBe(false); // too short
+    expect(isLegalPersonChittyId(null)).toBe(false);
+    expect(isLegalPersonChittyId(undefined)).toBe(false);
+    expect(isLegalPersonChittyId(42)).toBe(false);
+  });
+});
+
+describe('getLegalPersonChittyId / setLegalPersonChittyId', () => {
+  it('returns null when metadata is absent or missing the key', () => {
+    expect(getLegalPersonChittyId(null)).toBeNull();
+    expect(getLegalPersonChittyId(undefined)).toBeNull();
+    expect(getLegalPersonChittyId({ metadata: null })).toBeNull();
+    expect(getLegalPersonChittyId({ metadata: {} })).toBeNull();
+    expect(getLegalPersonChittyId({ metadata: { other: 'x' } })).toBeNull();
+  });
+
+  it('reads the binding when present', () => {
+    const account = { metadata: { [LEGAL_PERSON_METADATA_KEY]: LEGAL_PERSON_ID, other: 'kept' } };
+    expect(getLegalPersonChittyId(account)).toBe(LEGAL_PERSON_ID);
+  });
+
+  it('setLegalPersonChittyId is pure and preserves other metadata', () => {
+    const original = { existing: 'value' };
+    const next = setLegalPersonChittyId(original, LEGAL_PERSON_ID);
+    expect(next).toEqual({ existing: 'value', [LEGAL_PERSON_METADATA_KEY]: LEGAL_PERSON_ID });
+    expect(original).toEqual({ existing: 'value' }); // unmutated
+  });
+
+  it('setLegalPersonChittyId handles null/undefined metadata', () => {
+    expect(setLegalPersonChittyId(null, LEGAL_PERSON_ID)).toEqual({
+      [LEGAL_PERSON_METADATA_KEY]: LEGAL_PERSON_ID,
+    });
+    expect(setLegalPersonChittyId(undefined, LEGAL_PERSON_ID)).toEqual({
+      [LEGAL_PERSON_METADATA_KEY]: LEGAL_PERSON_ID,
+    });
+  });
+
+  it('setLegalPersonChittyId rejects malformed and non-Person ChittyIDs', () => {
+    expect(() => setLegalPersonChittyId({}, 'bogus')).toThrow(/Invalid Legal Person ChittyID/);
+    expect(() => setLegalPersonChittyId({}, LOCATION_ID)).toThrow(/Invalid Legal Person ChittyID/);
+  });
+
+  it('round-trip: set then get yields the original ID', () => {
+    const next = setLegalPersonChittyId({ other: 1 }, LEGAL_PERSON_ID);
+    expect(getLegalPersonChittyId({ metadata: next })).toBe(LEGAL_PERSON_ID);
+  });
+});
+
+describe('checkLegalPersonBinding (runtime reconciliation flag)', () => {
+  const tenantId = '00000000-0000-0000-0000-000000000abc';
+
+  it('returns null when Mercury account has a valid binding', () => {
+    const flag = checkLegalPersonBinding({
+      source: 'mercury',
+      tenantId,
+      accountId: 'acct-1',
+      externalId: 'mercury:abc',
+      metadata: { [LEGAL_PERSON_METADATA_KEY]: LEGAL_PERSON_ID },
+    });
+    expect(flag).toBeNull();
+  });
+
+  it('returns a structured flag when Mercury binding is missing', () => {
+    const flag = checkLegalPersonBinding({
+      source: 'mercury',
+      tenantId,
+      accountId: 'acct-1',
+      externalId: 'mercury:abc',
+      metadata: null,
+    });
+    expect(flag).not.toBeNull();
+    expect(flag).toMatchObject({
+      code: 'missing_legal_person_chittyid',
+      severity: 'reconciliation',
+      source: 'mercury',
+      tenantId,
+      accountId: 'acct-1',
+      externalId: 'mercury:abc',
+    });
+    expect(flag!.message).toMatch(/Path B/);
+  });
+
+  it('flags an invalid (non-P) ChittyID in metadata as missing', () => {
+    const flag = checkLegalPersonBinding({
+      source: 'mercury',
+      tenantId,
+      metadata: { [LEGAL_PERSON_METADATA_KEY]: LOCATION_ID },
+    });
+    expect(flag).not.toBeNull();
+    expect(flag!.code).toBe('missing_legal_person_chittyid');
+  });
+
+  it('does NOT throw — partial enforcement per contract', () => {
+    // The whole point of returning a flag instead of throwing: webhook
+    // ingestion must continue, reconciliation reports surface the gap.
+    expect(() =>
+      checkLegalPersonBinding({ source: 'mercury', tenantId, metadata: null }),
+    ).not.toThrow();
+  });
+
+  it('returns null for non-Mercury sources (Wave/Stripe not bound today)', () => {
+    expect(checkLegalPersonBinding({ source: 'wave', tenantId, metadata: null })).toBeNull();
+    expect(checkLegalPersonBinding({ source: 'stripe', tenantId, metadata: null })).toBeNull();
+    expect(checkLegalPersonBinding({ source: 'unknown', tenantId, metadata: null })).toBeNull();
+  });
+});

--- a/server/books/webhooks.ts
+++ b/server/books/webhooks.ts
@@ -6,6 +6,7 @@ import { SystemStorage } from '../storage/system';
 import { findAccountCode } from '../../database/chart-of-accounts';
 import { validateRow } from '../lib/chittyschema';
 import { ledgerLog } from '../lib/ledger-client';
+import { checkLegalPersonBinding, type LegalPersonBindingFlag } from '../lib/legal-person-binding';
 
 export const webhookRoutes = new Hono<HonoEnv>();
 
@@ -286,10 +287,12 @@ webhookRoutes.post('/api/webhooks/mercury/:tenantId', async (c) => {
 
   // Resolve local account from Mercury accountId, or use first active account for tenant
   let accountId: string | null = null;
+  let resolvedAccountMetadata: Record<string, unknown> | null = null;
   if (mercuryAccountId) {
     const acct = await storage.lookupAccountByExternalId(`mercury:${mercuryAccountId}`);
     if (acct && acct.tenantId === tenantId) {
       accountId = acct.id;
+      resolvedAccountMetadata = (acct.metadata as Record<string, unknown> | null) ?? null;
     }
   }
   if (!accountId) {
@@ -298,6 +301,7 @@ webhookRoutes.post('/api/webhooks/mercury/:tenantId', async (c) => {
     const active = accounts.find((a) => a.isActive);
     if (active) {
       accountId = active.id;
+      resolvedAccountMetadata = (active.metadata as Record<string, unknown> | null) ?? null;
     } else {
       const created = await storage.createAccount({
         tenantId,
@@ -307,7 +311,23 @@ webhookRoutes.post('/api/webhooks/mercury/:tenantId', async (c) => {
         externalId: mercuryAccountId ? `mercury:${mercuryAccountId}` : undefined,
       });
       accountId = created.id;
+      resolvedAccountMetadata = (created.metadata as Record<string, unknown> | null) ?? null;
     }
+  }
+
+  // Path B runtime check: emit a structured reconciliation flag when the
+  // legal_person_chittyid binding is missing from account metadata. This
+  // does NOT block ingestion — the contract treats it as partial
+  // enforcement until Path A (column add) lands.
+  const bindingFlag: LegalPersonBindingFlag | null = checkLegalPersonBinding({
+    source: 'mercury',
+    tenantId,
+    accountId: accountId ?? undefined,
+    externalId: mercuryAccountId ? `mercury:${mercuryAccountId}` : null,
+    metadata: resolvedAccountMetadata,
+  });
+  if (bindingFlag) {
+    console.warn('[webhook:mercury] reconciliation flag', bindingFlag);
   }
 
   // Advisory ChittySchema validation
@@ -357,6 +377,7 @@ webhookRoutes.post('/api/webhooks/mercury/:tenantId', async (c) => {
       confidence: classificationConfidence,
       schemaAdvisory: schemaResult.advisory,
       schemaValid: schemaResult.ok,
+      reconciliationFlag: bindingFlag,
     },
   }, c.env);
 
@@ -366,6 +387,7 @@ webhookRoutes.post('/api/webhooks/mercury/:tenantId', async (c) => {
     suggestedCoaCode,
     classificationConfidence,
     schemaAdvisory: schemaResult.advisory,
+    reconciliationFlags: bindingFlag ? [bindingFlag] : [],
   }, 201);
 });
 
@@ -433,6 +455,19 @@ webhookRoutes.post('/api/webhooks/mercury', async (c) => {
     return c.json({ received: true, duplicate: true, transactionId: dupRow.id }, 202);
   }
 
+  // Path B runtime check (legacy normalized path).
+  const acctForBinding = await storage.getAccount(tx.accountId, tx.tenantId);
+  const bindingFlag: LegalPersonBindingFlag | null = checkLegalPersonBinding({
+    source: 'mercury',
+    tenantId: tx.tenantId,
+    accountId: tx.accountId,
+    externalId: acctForBinding?.externalId ?? null,
+    metadata: (acctForBinding?.metadata as Record<string, unknown> | null) ?? null,
+  });
+  if (bindingFlag) {
+    console.warn('[webhook:mercury] reconciliation flag', bindingFlag);
+  }
+
   const created = await storage.createTransaction({
     tenantId: tx.tenantId,
     accountId: tx.accountId,
@@ -459,6 +494,7 @@ webhookRoutes.post('/api/webhooks/mercury', async (c) => {
       confidence: classificationConfidence,
       schemaAdvisory: schemaResult.advisory,
       schemaValid: schemaResult.ok,
+      reconciliationFlag: bindingFlag,
     },
   }, c.env);
 
@@ -468,6 +504,7 @@ webhookRoutes.post('/api/webhooks/mercury', async (c) => {
     suggestedCoaCode,
     classificationConfidence,
     schemaAdvisory: schemaResult.advisory,
+    reconciliationFlags: bindingFlag ? [bindingFlag] : [],
   }, 201);
 });
 

--- a/server/lib/legal-person-binding.ts
+++ b/server/lib/legal-person-binding.ts
@@ -1,0 +1,133 @@
+/**
+ * Legal Person ChittyID binding for Mercury accounts (Path B — interim).
+ *
+ * Per docs/contracts/mercury-multitenant.md, every Mercury account must bind
+ * to exactly one Legal Person (`P-Legal` entity) recorded as
+ * `legal_person_chittyid`. The dedicated column is deferred to Path A
+ * (coordinated cutover required; drizzle-kit push is destructive per
+ * CLAUDE.md "Schema Changes").
+ *
+ * Until Path A lands, the binding lives in `accounts.metadata->>'legal_person_chittyid'`.
+ * This module is the single read/write surface so the eventual column add
+ * is a one-line swap.
+ *
+ * @canon: chittycanon://gov/governance#core-types — ChittyID format
+ *         VV-G-LLL-SSSS-T-YM-C-X where T ∈ {P, L, T, E, A}. For a
+ *         Legal Person, T = P and subtype is "Legal".
+ */
+import type { Account } from '../../database/system.schema';
+
+export const LEGAL_PERSON_METADATA_KEY = 'legal_person_chittyid' as const;
+
+/**
+ * ChittyID format check.
+ *
+ * Canonical shape: `VV-G-LLL-SSSS-T-YM-C-X` (8 dash-separated groups).
+ * Group 5 (T) must be one of P / L / T / E / A. For a legal-person binding
+ * we require T = P (Person). The Legal/Synthetic/Natural distinction is
+ * encoded in a sibling subtype slot upstream and isn't directly visible in
+ * the ID itself, so we accept any T=P ChittyID here and rely on
+ * ChittyConnect / ChittyID to vouch for the L (Legal) subtype.
+ */
+const CHITTYID_RE = /^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-([PLTEA])-[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]$/;
+
+export function isLegalPersonChittyId(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = CHITTYID_RE.exec(value);
+  if (!match) return false;
+  return match[1] === 'P';
+}
+
+/**
+ * Read the legal_person_chittyid binding from an account row.
+ *
+ * Returns null when the binding is absent. Callers MUST treat null as a
+ * reconciliation flag rather than an error — the contract is partially
+ * enforced until Path A lands.
+ */
+export function getLegalPersonChittyId(account: Pick<Account, 'metadata'> | null | undefined): string | null {
+  if (!account) return null;
+  const meta = account.metadata;
+  if (!meta || typeof meta !== 'object') return null;
+  const raw = (meta as Record<string, unknown>)[LEGAL_PERSON_METADATA_KEY];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+/**
+ * Produce a new metadata object with the legal_person_chittyid binding set.
+ *
+ * Pure — does not mutate the input. Throws on invalid ChittyID shape (this
+ * is a write path; we want validation errors loud here). The runtime
+ * reconciliation flag fires on the read side, where missingness is
+ * expected during the Path A transition.
+ */
+export function setLegalPersonChittyId<M extends Record<string, unknown> | null | undefined>(
+  metadata: M,
+  chittyId: string,
+): Record<string, unknown> {
+  if (!isLegalPersonChittyId(chittyId)) {
+    throw new Error(`Invalid Legal Person ChittyID: ${chittyId}`);
+  }
+  const base = metadata && typeof metadata === 'object' ? { ...(metadata as Record<string, unknown>) } : {};
+  base[LEGAL_PERSON_METADATA_KEY] = chittyId;
+  return base;
+}
+
+/**
+ * Structured reconciliation flag emitted when a Mercury-sourced account is
+ * read or written without a legal_person_chittyid binding.
+ *
+ * Per contract:
+ *   "Reconciliation reports MUST flag this in their output until the gap closes."
+ *
+ * This is a value, not a thrown error. The webhook write path must NOT
+ * reject the event; the legacy data flow predates the binding requirement
+ * and the contract treats this as partial enforcement, not invalid input.
+ */
+export interface LegalPersonBindingFlag {
+  code: 'missing_legal_person_chittyid';
+  severity: 'reconciliation';
+  source: 'mercury' | 'wave' | 'stripe' | 'unknown';
+  tenantId: string;
+  accountId?: string;
+  externalId?: string | null;
+  message: string;
+}
+
+export interface CheckBindingInput {
+  source: 'mercury' | 'wave' | 'stripe' | 'unknown';
+  tenantId: string;
+  accountId?: string;
+  externalId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Runtime check for the Mercury write path.
+ *
+ * Returns a flag object when the binding is missing for a source that
+ * requires it (Mercury today; Wave/Stripe reserved for future bindings).
+ * Returns null when the binding is present or the source does not require it.
+ *
+ * Callers SHOULD include the returned flag in their response payload and
+ * the audit ledger so reconciliation reports can surface it.
+ */
+export function checkLegalPersonBinding(input: CheckBindingInput): LegalPersonBindingFlag | null {
+  if (input.source !== 'mercury') return null;
+  const meta = input.metadata;
+  const raw = meta && typeof meta === 'object' ? (meta as Record<string, unknown>)[LEGAL_PERSON_METADATA_KEY] : undefined;
+  if (typeof raw === 'string' && raw.length > 0 && isLegalPersonChittyId(raw)) {
+    return null;
+  }
+  return {
+    code: 'missing_legal_person_chittyid',
+    severity: 'reconciliation',
+    source: input.source,
+    tenantId: input.tenantId,
+    accountId: input.accountId,
+    externalId: input.externalId ?? null,
+    message:
+      'Mercury account is missing legal_person_chittyid binding (Path B metadata). ' +
+      'Reconciliation reports will flag this until the dedicated column lands (Path A).',
+  };
+}


### PR DESCRIPTION
## Summary
- Implements **Path B** from `docs/contracts/mercury-multitenant.md` (PR #119): store `legal_person_chittyid` in `accounts.metadata` behind a typed helper so the eventual column add (Path A) is a one-line swap.
- New `server/lib/legal-person-binding.ts`: `isLegalPersonChittyId` (T=P enforced per canonical `VV-G-LLL-SSSS-T-YM-C-X`), `getLegalPersonChittyId`, `setLegalPersonChittyId`, and `checkLegalPersonBinding` which returns a structured `LegalPersonBindingFlag` instead of throwing.
- Wired into both Mercury webhook handlers in `server/books/webhooks.ts` (native `/api/webhooks/mercury/:tenantId` and legacy normalized `/api/webhooks/mercury`). The flag is added to the audit ledger metadata and the response payload as `reconciliationFlags[]`. Ingestion is never blocked — per contract, this is partial enforcement until Path A lands.
- 14 real unit tests in `server/__tests__/legal-person-binding.test.ts`, no DB mocks.

## Path A follow-up (not in this PR)
A proper `legal_person_chittyid TEXT NOT NULL` column on `accounts` still needs to land. It requires a **coordinated cutover** because:
1. `drizzle-kit push` is destructive per CLAUDE.md "Schema Changes" (no migrations in this repo).
2. The column must be added `NULL`-first, backfilled from `metadata->>'legal_person_chittyid'` for every existing Mercury account, and only then flipped to `NOT NULL`.
3. ChittyConnect must be ready to vend the Legal Person ChittyID at account-create time before the constraint goes hot.

Until Path A: reconciliation reports SHOULD consume `reconciliationFlags[]` from the webhook response / ledger to surface missing bindings.

## Test plan
- [x] `npm run check` clean
- [x] `npx vitest run server/__tests__/legal-person-binding.test.ts` — 14 passing
- [ ] Live Mercury webhook send (in staging) returns `reconciliationFlags: [{code: 'missing_legal_person_chittyid', ...}]` for an unbound account
- [ ] Backfill metadata for IT CAN BE LLC Mercury accounts and verify flag clears

Generated with Claude Code