### PR TITLE
docs(agents): add chittyagent-google to agent interaction table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Authentication: Bearer service token. See [SECURITY.md](SECURITY.md).
 | `chittyagent-connect` | Outbound (runtime) | Mercury Bank proxy — every bank API call routes through ChittyConnect |
 | `chittyagent-canon` | Inbound (CI) | Audits this repo for canonical pattern adherence |
 | `chittyagent-cloudflare` | Outbound (admin) | Hyperdrive, KV, Email Service, WAF rules |
+| `chittyagent-google` | Outbound (runtime) | Google Workspace MCP gateway — Gmail (bank notifications, evidence), Drive (document storage), Sheets (export targets), Calendar (scheduling). Hybrid: dynamic MCP discovery + static gap-fillers |
 | `chittyagent-notion` | Outbound (state) | Project + Actions DB updates from session lifecycle hooks |
 
 ## ChittyOS Subagents Useful for Development


### PR DESCRIPTION
Adds `chittyagent-google` to the ChittyOS agent interaction table in AGENTS.md.

**Direction**: Outbound (runtime)
**Purpose**: Google Workspace MCP gateway — Gmail (bank notifications, evidence), Drive (document storage), Sheets (export targets), Calendar (scheduling). Hybrid: dynamic MCP discovery + static gap-fillers.

Companion to chittyos/chittyentity#510 which implements the agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Workspace integration through a new ChittyOS agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->